### PR TITLE
Feature - (2.0.0-beta) 'node' connection mode

### DIFF
--- a/PeerConnectivity.podspec
+++ b/PeerConnectivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PeerConnectivity"
-  s.version      = "1.0.0"
+  s.version      = "2.0.0-beta"
 
   s.summary      = "Functional wrapper for Apple's MultipeerConnectivity framework."
   s.description  = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { "Reid Chatham" => "reid.chatham@gmail.com" }
   s.homepage     = "https://github.com/tillersystems/PeerConnectivity"
 
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
   s.ios.deployment_target = '10.1'
 
   s.source       = { :git => "https://github.com/tillersystems/PeerConnectivity.git", :tag => "#{s.version}" }

--- a/PeerConnectivity.xcodeproj/project.pbxproj
+++ b/PeerConnectivity.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		3080C7FC1D80A1D700AF9EA3 /* PeerSessionEventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080C7EB1D80A1D600AF9EA3 /* PeerSessionEventProducer.swift */; };
 		3086CD2D1D09FB9900E269A3 /* PeerConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3086CD221D09FB9800E269A3 /* PeerConnectivity.framework */; };
 		3086CD321D09FB9900E269A3 /* PeerConnectivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3086CD311D09FB9900E269A3 /* PeerConnectivityTests.swift */; };
+		9C8518E42182172D000C5C3F /* PeerConnectionManager+Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8518E32182172D000C5C3F /* PeerConnectionManager+Peer.swift */; };
+		9C8518E621821763000C5C3F /* PeerConnectionManager+Listener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8518E521821763000C5C3F /* PeerConnectionManager+Listener.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +61,8 @@
 		3086CD2C1D09FB9900E269A3 /* PeerConnectivityTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PeerConnectivityTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3086CD311D09FB9900E269A3 /* PeerConnectivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerConnectivityTests.swift; sourceTree = "<group>"; };
 		3086CD331D09FB9900E269A3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9C8518E32182172D000C5C3F /* PeerConnectionManager+Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "PeerConnectionManager+Peer.swift"; path = "Sources/PeerConnectionManager+Peer.swift"; sourceTree = "<group>"; };
+		9C8518E521821763000C5C3F /* PeerConnectionManager+Listener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "PeerConnectionManager+Listener.swift"; path = "Sources/PeerConnectionManager+Listener.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +93,8 @@
 				9C805C8F2162847B006FA28D /* ObserverResponder */,
 				3080C7DE1D80A1D600AF9EA3 /* Peer.swift */,
 				3080C7E71D80A1D600AF9EA3 /* PeerConnectionManager.swift */,
+				9C8518E32182172D000C5C3F /* PeerConnectionManager+Peer.swift */,
+				9C8518E521821763000C5C3F /* PeerConnectionManager+Listener.swift */,
 				9C805C91216284B5006FA28D /* supporting-files */,
 			);
 			name = Sources;
@@ -299,6 +305,7 @@
 				3080C7F91D80A1D700AF9EA3 /* PeerConnectionResponder.swift in Sources */,
 				3080C7F71D80A1D700AF9EA3 /* PeerBrowserViewControllerEventProducer.swift in Sources */,
 				3080C7F41D80A1D700AF9EA3 /* PeerBrowser.swift in Sources */,
+				9C8518E621821763000C5C3F /* PeerConnectionManager+Listener.swift in Sources */,
 				3080C7F31D80A1D700AF9EA3 /* PeerAdvertiserEventProducer.swift in Sources */,
 				3080C7FC1D80A1D700AF9EA3 /* PeerSessionEventProducer.swift in Sources */,
 				3080C7F51D80A1D700AF9EA3 /* PeerBrowserAssisstant.swift in Sources */,
@@ -306,6 +313,7 @@
 				3080C7EE1D80A1D700AF9EA3 /* Observable.swift in Sources */,
 				3080C7ED1D80A1D700AF9EA3 /* MultiObservable.swift in Sources */,
 				3080C7F61D80A1D700AF9EA3 /* PeerBrowserEventProducer.swift in Sources */,
+				9C8518E42182172D000C5C3F /* PeerConnectionManager+Peer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PeerConnectivity.xcodeproj/project.pbxproj
+++ b/PeerConnectivity.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -442,7 +442,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -469,7 +469,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -492,7 +491,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
@@ -504,7 +502,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rchatham.PeerConnectivityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -515,7 +512,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.rchatham.PeerConnectivityTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/PeerConnectivity.xcodeproj/project.pbxproj
+++ b/PeerConnectivity.xcodeproj/project.pbxproj
@@ -83,23 +83,13 @@
 		301475781D7112A500F43337 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				3080C7DB1D80A1D600AF9EA3 /* Info.plist */,
-				3080C7DC1D80A1D600AF9EA3 /* MultiObservable.swift */,
-				3080C7DD1D80A1D600AF9EA3 /* Observable.swift */,
+				9C805C8C2162842C006FA28D /* Session */,
+				9C805C8D21628443006FA28D /* Adviser */,
+				9C805C8E21628457006FA28D /* Browser */,
+				9C805C8F2162847B006FA28D /* ObserverResponder */,
 				3080C7DE1D80A1D600AF9EA3 /* Peer.swift */,
-				3080C7DF1D80A1D600AF9EA3 /* PeerAdvertiser.swift */,
-				3080C7E01D80A1D600AF9EA3 /* PeerAdvertiserAssisstant.swift */,
-				3080C7E11D80A1D600AF9EA3 /* PeerAdvertiserAssisstantEventProducer.swift */,
-				3080C7E21D80A1D600AF9EA3 /* PeerAdvertiserEventProducer.swift */,
-				3080C7E31D80A1D600AF9EA3 /* PeerBrowser.swift */,
-				3080C7E41D80A1D600AF9EA3 /* PeerBrowserAssisstant.swift */,
-				3080C7E51D80A1D600AF9EA3 /* PeerBrowserEventProducer.swift */,
-				3080C7E61D80A1D600AF9EA3 /* PeerBrowserViewControllerEventProducer.swift */,
 				3080C7E71D80A1D600AF9EA3 /* PeerConnectionManager.swift */,
-				3080C7E81D80A1D600AF9EA3 /* PeerConnectionResponder.swift */,
-				3080C7E91D80A1D600AF9EA3 /* PeerConnectivity.h */,
-				3080C7EA1D80A1D600AF9EA3 /* PeerSession.swift */,
-				3080C7EB1D80A1D600AF9EA3 /* PeerSessionEventProducer.swift */,
+				9C805C91216284B5006FA28D /* supporting-files */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -129,6 +119,64 @@
 				3086CD331D09FB9900E269A3 /* Info.plist */,
 			);
 			path = PeerConnectivityTests;
+			sourceTree = "<group>";
+		};
+		9C805C8C2162842C006FA28D /* Session */ = {
+			isa = PBXGroup;
+			children = (
+				3080C7EA1D80A1D600AF9EA3 /* PeerSession.swift */,
+				3080C7EB1D80A1D600AF9EA3 /* PeerSessionEventProducer.swift */,
+			);
+			name = Session;
+			sourceTree = "<group>";
+		};
+		9C805C8D21628443006FA28D /* Adviser */ = {
+			isa = PBXGroup;
+			children = (
+				9C805C902162849A006FA28D /* Assistant */,
+				3080C7DF1D80A1D600AF9EA3 /* PeerAdvertiser.swift */,
+				3080C7E21D80A1D600AF9EA3 /* PeerAdvertiserEventProducer.swift */,
+			);
+			name = Adviser;
+			sourceTree = "<group>";
+		};
+		9C805C8E21628457006FA28D /* Browser */ = {
+			isa = PBXGroup;
+			children = (
+				3080C7E31D80A1D600AF9EA3 /* PeerBrowser.swift */,
+				3080C7E41D80A1D600AF9EA3 /* PeerBrowserAssisstant.swift */,
+				3080C7E51D80A1D600AF9EA3 /* PeerBrowserEventProducer.swift */,
+				3080C7E61D80A1D600AF9EA3 /* PeerBrowserViewControllerEventProducer.swift */,
+			);
+			name = Browser;
+			sourceTree = "<group>";
+		};
+		9C805C8F2162847B006FA28D /* ObserverResponder */ = {
+			isa = PBXGroup;
+			children = (
+				3080C7DC1D80A1D600AF9EA3 /* MultiObservable.swift */,
+				3080C7DD1D80A1D600AF9EA3 /* Observable.swift */,
+				3080C7E81D80A1D600AF9EA3 /* PeerConnectionResponder.swift */,
+			);
+			name = ObserverResponder;
+			sourceTree = "<group>";
+		};
+		9C805C902162849A006FA28D /* Assistant */ = {
+			isa = PBXGroup;
+			children = (
+				3080C7E01D80A1D600AF9EA3 /* PeerAdvertiserAssisstant.swift */,
+				3080C7E11D80A1D600AF9EA3 /* PeerAdvertiserAssisstantEventProducer.swift */,
+			);
+			name = Assistant;
+			sourceTree = "<group>";
+		};
+		9C805C91216284B5006FA28D /* supporting-files */ = {
+			isa = PBXGroup;
+			children = (
+				3080C7DB1D80A1D600AF9EA3 /* Info.plist */,
+				3080C7E91D80A1D600AF9EA3 /* PeerConnectivity.h */,
+			);
+			name = "supporting-files";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -412,7 +460,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -435,7 +483,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.rchatham.PeerConnectivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/PeerConnectivity.xcworkspace/contents.xcworkspacedata
+++ b/PeerConnectivity.xcworkspace/contents.xcworkspacedata
@@ -5,9 +5,9 @@
       location = "group:PeerPlayground.playground">
    </FileRef>
    <FileRef
-      location = "group:PeerConnectivityDemo.xcodeproj">
+      location = "container:PeerConnectivity.xcodeproj">
    </FileRef>
    <FileRef
-      location = "container:PeerConnectivity.xcodeproj">
+      location = "group:PeerConnectivityDemo.xcodeproj">
    </FileRef>
 </Workspace>

--- a/PeerConnectivityDemo.xcodeproj/project.pbxproj
+++ b/PeerConnectivityDemo.xcodeproj/project.pbxproj
@@ -12,18 +12,17 @@
 		309837401D8A8D600002338A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3098373E1D8A8D600002338A /* Main.storyboard */; };
 		309837421D8A8D600002338A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 309837411D8A8D600002338A /* Assets.xcassets */; };
 		309837451D8A8D600002338A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 309837431D8A8D600002338A /* LaunchScreen.storyboard */; };
-		309837641D8B4FAC0002338A /* PeerConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 309837621D8A8E6A0002338A /* PeerConnectivity.framework */; };
-		309837651D8B4FAC0002338A /* PeerConnectivity.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 309837621D8A8E6A0002338A /* PeerConnectivity.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9CC3B263216222660062CC8A /* PeerConnectivity.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9CC3B2602162221C0062CC8A /* PeerConnectivity.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		309837661D8B4FAC0002338A /* Embed Frameworks */ = {
+		9CC3B264216222660062CC8A /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				309837651D8B4FAC0002338A /* PeerConnectivity.framework in Embed Frameworks */,
+				9CC3B263216222660062CC8A /* PeerConnectivity.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -39,6 +38,7 @@
 		309837441D8A8D600002338A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		309837461D8A8D600002338A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		309837621D8A8E6A0002338A /* PeerConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PeerConnectivity.framework; path = "../../Library/Developer/Xcode/DerivedData/PeerConnectivity-gpwpzbfgjijtrdbmsejdioisajvt/Build/Products/Debug-iphoneos/PeerConnectivity.framework"; sourceTree = "<group>"; };
+		9CC3B2602162221C0062CC8A /* PeerConnectivity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PeerConnectivity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,7 +46,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				309837641D8B4FAC0002338A /* PeerConnectivity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,6 +85,7 @@
 		309837611D8A8E6A0002338A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9CC3B2602162221C0062CC8A /* PeerConnectivity.framework */,
 				309837621D8A8E6A0002338A /* PeerConnectivity.framework */,
 			);
 			name = Frameworks;
@@ -101,7 +101,7 @@
 				309837331D8A8D600002338A /* Sources */,
 				309837341D8A8D600002338A /* Frameworks */,
 				309837351D8A8D600002338A /* Resources */,
-				309837661D8B4FAC0002338A /* Embed Frameworks */,
+				9CC3B264216222660062CC8A /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -124,7 +124,7 @@
 				TargetAttributes = {
 					309837361D8A8D600002338A = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = NT7FFBVKUP;
+						DevelopmentTeam = FJA37BA54H;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -309,7 +309,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = NT7FFBVKUP;
+				DEVELOPMENT_TEAM = FJA37BA54H;
 				INFOPLIST_FILE = PeerConnectivityDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -323,7 +323,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = NT7FFBVKUP;
+				DEVELOPMENT_TEAM = FJA37BA54H;
 				INFOPLIST_FILE = PeerConnectivityDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/PeerConnectivityDemo/AppDelegate.swift
+++ b/PeerConnectivityDemo/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/PeerConnectivityDemo/ViewController.swift
+++ b/PeerConnectivityDemo/ViewController.swift
@@ -11,7 +11,7 @@ import PeerConnectivity
 
 class ViewController: UIViewController {
     
-    fileprivate lazy var pcm : PeerConnectionManager = {
+    fileprivate lazy var pcm: PeerConnectionManager = {
         var pcm = PeerConnectionManager(serviceType: "local")
         pcm.listenOn({ [weak self] (event) in
             
@@ -45,19 +45,19 @@ class ViewController: UIViewController {
     
     fileprivate var isConnecting = false
     
-    fileprivate var connectionButton : UIButton!
-    fileprivate var userStatusLabel : UILabel!
+    fileprivate var connectionButton: UIButton!
+    fileprivate var userStatusLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         
-        connectionButton = UIButton(type: UIButtonType.system)
+        connectionButton = UIButton(type: UIButton.ButtonType.system)
         connectionButton.setTitle("Start networking!", for: .normal)
         connectionButton.setTitleColor(.blue, for: .normal)
         connectionButton.sizeToFit()
         connectionButton.center = view.center
-        connectionButton.addTarget(self, action: #selector(tappedConnectionButton(sender:)), for: UIControlEvents.touchUpInside)
+        connectionButton.addTarget(self, action: #selector(tappedConnectionButton(sender:)), for: UIControl.Event.touchUpInside)
         view.addSubview(connectionButton)
         
         userStatusLabel = UILabel()
@@ -75,7 +75,7 @@ class ViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
 
-    internal func tappedConnectionButton(sender: UIButton) {
+    @objc internal func tappedConnectionButton(sender: UIButton) {
         switch isConnecting {
         case false:
             pcm.start()

--- a/PeerPlayground.playground/Contents.swift
+++ b/PeerPlayground.playground/Contents.swift
@@ -1,264 +1,264 @@
-//: Playground - noun: a place where people can play
-
-import UIKit
-import PeerConnectivity
-
-
-/*:
- Welcome to the PeerPlayground!
- 
- This playground shows the general workflow of using the PeerConnectivity framework.
- 
- The basics:
-    1) Creating a PeerConnectionManager
-    2) Handling invitations
-    3) Sending information
-    4) Handling incoming information
-*/
-
-
-
-// MARK: Creating/Stopping/Starting the manager
-
-// Default joins mpc rooms automatically and uses the users device name as the display name
-var pcm = PeerConnectionManager(serviceType: "local")
-
-// Start peerconnectivity
-pcm.start()
-
-// Stop the connection manager
-// Always stop running connection managers before changing
-pcm.stop()
-
-// Can join chatrooms using PeerConnectionType.Automatic, .InviteOnly, and .Custom
-//  - .Automatic : automatically searches and joins other devices with the same service type
-//  - .InviteOnly : provides a browserViewController and invite alert controllers
-//  - .Custom : no default behavior is implemented
-
-// The manager can be initialized with a contructed peer representing the local user
-// with a custom displayName
-
-pcm = PeerConnectionManager(serviceType: "local", connectionType: .custom, displayName: "I_AM_KING")
-
-pcm.browserViewController { (event) in
-    
-}
-
-// Start again at any time
-pcm.start() {
-    // Do something when finished starting the session
-}
-
-
-
-// MARK: - Inviting peers/ Handling invitations
-
-pcm.listenOn({ (event: PeerConnectionEvent) in
-    
-    switch event {
-    case .foundPeer(let peer):
-        print("Found peer \(peer.displayName)")
-    
-        // This is already handled if you initialize the PeerConnectionManager
-        // with PeerConnectionType.automatic.
-    
-        // Invite peer to your session easily
-        pcm.invitePeer(peer)
-    
-        // Invite peers with context data
-        let someInfoAboutSession = [
-            "thisSession" : "isCool"
-        ]
-        let sessionContextData = NSKeyedArchiver.archivedData(withRootObject: someInfoAboutSession)
-        pcm.invitePeer(peer, withContext: sessionContextData, timeout: 10)
-        
-    case .lostPeer(let peer):
-        print("Lost peer \(peer.displayName)")
-        
-    case .receivedInvitation(let peer, let context, let invitationHandler):
-        print("\(peer.displayName) invited you to join their session")
-        
-        var shouldJoin = false
-        
-        defer {
-            invitationHandler(shouldJoin)
-        }
-        
-        guard let context = context,
-            let invitationContext = NSKeyedUnarchiver.unarchiveObject(with: context) as? [String:String],
-            let isItCool = invitationContext["thisSession"]
-            else { return }
-        
-        shouldJoin = (isItCool == "isCool")
-        
-    default: break
-    }
-}, withKey: "connectAutomaticallyIfItsCool")
-
-// Refresh an active session. This will cause you to lose connection to your current session.
-// Use after changing information affecting how you want to connect to peers.
-// Calls .stop() then .start()
-pcm.refresh() {
-    // Do something after the session restarts
-}
-
-// Found peers includes peers that have already joined the session
-let peersAvailableForInvite = pcm.foundPeers.filter{ !pcm.connectedPeers.contains($0) }
-
-// Invite them manually at any time
-for peer in peersAvailableForInvite {
-    pcm.invitePeer(peer)
-}
-
-
-
-// MARK: - Sending Events/Information
-
-// Create events as [String:AnyObject] Dictionaries
-let event: [String: Any] = [
-    "eventKey" : Date()
-]
-
-// Sends to all connected peers
-pcm.sendEvent(event)
-
-// Use this to access the connectedPeers
-let connectedPeers: [Peer] = pcm.connectedPeers
-
-if let somePeerThatIAmConnectedTo = connectedPeers.first {
-    
-    switch somePeerThatIAmConnectedTo.status {
-    case .currentUser:
-        print("Was created by current user")
-    default:
-        print("Something else happened")
-    }
-    
-    // Events can be sent to specific peers
-    pcm.sendEvent(event, toPeers: [somePeerThatIAmConnectedTo])
-    
-    do {
-        let stream = try pcm.sendDataStream(streamName: "some-stream", toPeer: somePeerThatIAmConnectedTo)
-        // Do something with stream
-    } catch let error {
-        print("Error: \(error)")
-    }
-    
-    
-    let progress: [Peer:Progress?] = pcm.sendResourceAtURL(NSURL(string: "someurl")! as URL, withName: "resource-name", toPeers: [somePeerThatIAmConnectedTo]) { (error: Error?) in
-        // Handle potential error
-        print("Error: \(error)")
-    }
-}
-
-
-
-// MARK: - Handling incoming events/notifications
-
-// It is generally a good idea to configure your peer session before calling .start()
-
-// Create an event listener
-pcm.observeEventListenerForKey("someEvent") { (eventInfo, peer) in
-    
-    print("Received some event \(eventInfo) from \(peer.displayName)")
-    guard let date = eventInfo["eventKey"] as? Date else { return }
-    print(date)
-    
-}
-// or...
-let eventListener: PeerConnectionEventListener = { event in
-    
-    switch event {
-        
-    case .ready: break
-    case .started: break
-    case .devicesChanged(let peer, let connectedPeers): break
-    case .receivedData(let peer, let data): break
-    case .receivedEvent(let peer, let eventInfo):
-    
-        print("Received some event \(eventInfo) from \(peer.displayName)")
-        guard let date = eventInfo["eventKey"] as? Date else { return }
-        print(date)
-        
-    case .receivedStream(let peer, let stream, let name): break
-    case .startedReceivingResource(let peer, let name, let progress): break
-    case .finishedReceivingResource(let peer, let name, let url, let error): break
-    case .receivedCertificate(let peer, let certificate, let handler): break
-    case .error(let error): break
-    case .ended: break
-    case .foundPeer(let peer): break
-    case .lostPeer(let peer): break
-    case .receivedInvitation(let peer, let context, let invitationHandler): break
-    }
-}
-
-// Set up listeners
-pcm.listenOn(eventListener, withKey: "someEvent")
-
-
-// Add and remove listeners at any time
-pcm.removeListenerForKey("someEvent")
-pcm.listenOn(eventListener, withKey: "someEvent")
-
-pcm.listenOn({ (event) in
-    
-    switch event {
-    case .devicesChanged(let peer, let connectedPeers):
-        
-        // Get informed about changes in the peers connected to the current session
-        switch peer.status {
-        case .connected :
-            print("\(peer.displayName) connected to session")
-        case .connecting :
-            print("\(peer.displayName) is attempting to connect")
-        case .notConnected :
-            print("\(peer.displayName) disconnected or was unable to connect")
-        default : break
-        }
-    default : break
-    }
-    
-}, withKey: "connectedDevicesChanged")
-
-// Listen to streams
-pcm.listenOn({ event in
-    
-    switch event {
-    case .receivedStream(let peer, let stream, let name):
-        print("Recieved stream with name: \(name) from peer: \(peer.displayName)")
-        // Do something with input stream
-        
-    default: break
-    }
-    
-}, withKey: "streamListener")
-
-// Receiving resources
-pcm.listenOn({ event in
-    
-    switch event {
-    case .startedReceivingResource(let peer, let name, let progress):
-        // Started receivng resource from peer
-        print("Receiving resource with name: \(name) from peer: \(peer.displayName) with progress: \(progress)")
-        
-    case .finishedReceivingResource(let peer, let name, let url, let error):
-        // Finished receiving resource from peer
-        print("Finished receiving resource with name: \(name) from peer: \(peer.displayName) at url: \(url.path) with error: \(error)")
-        
-    default: break
-    }
-    
-}, withKey: "resourceListener")
-
-
-
-// You should always stop the connection manager when you are done with it.
-// Starting a new manager without properly stopping other managers on the same device can
-// result in undefined behavior.
-pcm.stop()
-
-
-// TODO: - Extend service with NSNetService and Bonjour C API for manually
-//      configuring the PeerSession.
-// TODO: - Add Testing
-
+////: Playground - noun: a place where people can play
+//
+//import UIKit
+//import PeerConnectivity
+//
+//
+///*:
+// Welcome to the PeerPlayground!
+// 
+// This playground shows the general workflow of using the PeerConnectivity framework.
+// 
+// The basics:
+//    1) Creating a PeerConnectionManager
+//    2) Handling invitations
+//    3) Sending information
+//    4) Handling incoming information
+//*/
+//
+//
+//
+//// MARK: Creating/Stopping/Starting the manager
+//
+//// Default joins mpc rooms automatically and uses the users device name as the display name
+//var pcm = PeerConnectionManager(serviceType: "local")
+//
+//// Start peerconnectivity
+//pcm.start()
+//
+//// Stop the connection manager
+//// Always stop running connection managers before changing
+//pcm.stop()
+//
+//// Can join chatrooms using PeerConnectionType.Automatic, .InviteOnly, and .Custom
+////  - .Automatic: automatically searches and joins other devices with the same service type
+////  - .InviteOnly: provides a browserViewController and invite alert controllers
+////  - .Custom: no default behavior is implemented
+//
+//// The manager can be initialized with a contructed peer representing the local user
+//// with a custom displayName
+//
+//pcm = PeerConnectionManager(serviceType: "local", connectionType: .custom, displayName: "I_AM_KING")
+//
+//pcm.browserViewController { (event) in
+//    
+//}
+//
+//// Start again at any time
+//pcm.start() {
+//    // Do something when finished starting the session
+//}
+//
+//
+//
+//// MARK: - Inviting peers/ Handling invitations
+//
+//pcm.listenOn({ (event: PeerConnectionEvent) in
+//    
+//    switch event {
+//    case .foundPeer(let peer):
+//        print("Found peer \(peer.displayName)")
+//    
+//        // This is already handled if you initialize the PeerConnectionManager
+//        // with PeerConnectionType.automatic.
+//    
+//        // Invite peer to your session easily
+//        pcm.invitePeer(peer)
+//    
+//        // Invite peers with context data
+//        let someInfoAboutSession = [
+//            "thisSession": "isCool"
+//        ]
+//        let sessionContextData = NSKeyedArchiver.archivedData(withRootObject: someInfoAboutSession)
+//        pcm.invitePeer(peer, withContext: sessionContextData, timeout: 10)
+//        
+//    case .lostPeer(let peer):
+//        print("Lost peer \(peer.displayName)")
+//        
+//    case .receivedInvitation(let peer, let context, let invitationHandler):
+//        print("\(peer.displayName) invited you to join their session")
+//        
+//        var shouldJoin = false
+//        
+//        defer {
+//            invitationHandler(shouldJoin)
+//        }
+//        
+//        guard let context = context,
+//            let invitationContext = NSKeyedUnarchiver.unarchiveObject(with: context) as? [String:String],
+//            let isItCool = invitationContext["thisSession"]
+//            else { return }
+//        
+//        shouldJoin = (isItCool == "isCool")
+//        
+//    default: break
+//    }
+//}, withKey: "connectAutomaticallyIfItsCool")
+//
+//// Refresh an active session. This will cause you to lose connection to your current session.
+//// Use after changing information affecting how you want to connect to peers.
+//// Calls .stop() then .start()
+//pcm.refresh() {
+//    // Do something after the session restarts
+//}
+//
+//// Found peers includes peers that have already joined the session
+//let peersAvailableForInvite = pcm.foundPeers.filter{ !pcm.connectedPeers.contains($0) }
+//
+//// Invite them manually at any time
+//for peer in peersAvailableForInvite {
+//    pcm.invitePeer(peer)
+//}
+//
+//
+//
+//// MARK: - Sending Events/Information
+//
+//// Create events as [String:AnyObject] Dictionaries
+//let event: [String: Any] = [
+//    "eventKey": Date()
+//]
+//
+//// Sends to all connected peers
+//pcm.sendEvent(event)
+//
+//// Use this to access the connectedPeers
+//let connectedPeers: [Peer] = pcm.connectedPeers
+//
+//if let somePeerThatIAmConnectedTo = connectedPeers.first {
+//    
+//    switch somePeerThatIAmConnectedTo.status {
+//    case .currentUser:
+//        print("Was created by current user")
+//    default:
+//        print("Something else happened")
+//    }
+//    
+//    // Events can be sent to specific peers
+//    pcm.sendEvent(event, toPeers: [somePeerThatIAmConnectedTo])
+//    
+//    do {
+//        let stream = try pcm.sendDataStream(streamName: "some-stream", toPeer: somePeerThatIAmConnectedTo)
+//        // Do something with stream
+//    } catch let error {
+//        print("Error: \(error)")
+//    }
+//    
+//    
+//    let progress: [Peer:Progress?] = pcm.sendResourceAtURL(NSURL(string: "someurl")! as URL, withName: "resource-name", toPeers: [somePeerThatIAmConnectedTo]) { (error: Error?) in
+//        // Handle potential error
+//        print("Error: \(error)")
+//    }
+//}
+//
+//
+//
+//// MARK: - Handling incoming events/notifications
+//
+//// It is generally a good idea to configure your peer session before calling .start()
+//
+//// Create an event listener
+//pcm.observeEventListenerForKey("someEvent") { (eventInfo, peer) in
+//    
+//    print("Received some event \(eventInfo) from \(peer.displayName)")
+//    guard let date = eventInfo["eventKey"] as? Date else { return }
+//    print(date)
+//    
+//}
+//// or...
+//let eventListener: PeerConnectionEventListener = { event in
+//    
+//    switch event {
+//        
+//    case .ready: break
+//    case .started: break
+//    case .devicesChanged(let peer, let connectedPeers): break
+//    case .receivedData(let peer, let data): break
+//    case .receivedEvent(let peer, let eventInfo):
+//    
+//        print("Received some event \(eventInfo) from \(peer.displayName)")
+//        guard let date = eventInfo["eventKey"] as? Date else { return }
+//        print(date)
+//        
+//    case .receivedStream(let peer, let stream, let name): break
+//    case .startedReceivingResource(let peer, let name, let progress): break
+//    case .finishedReceivingResource(let peer, let name, let url, let error): break
+//    case .receivedCertificate(let peer, let certificate, let handler): break
+//    case .error(let error): break
+//    case .ended: break
+//    case .foundPeer(let peer): break
+//    case .lostPeer(let peer): break
+//    case .receivedInvitation(let peer, let context, let invitationHandler): break
+//    }
+//}
+//
+//// Set up listeners
+//pcm.listenOn(eventListener, withKey: "someEvent")
+//
+//
+//// Add and remove listeners at any time
+//pcm.removeListenerForKey("someEvent")
+//pcm.listenOn(eventListener, withKey: "someEvent")
+//
+//pcm.listenOn({ (event) in
+//    
+//    switch event {
+//    case .devicesChanged(let peer, let connectedPeers):
+//        
+//        // Get informed about changes in the peers connected to the current session
+//        switch peer.status {
+//        case .connected :
+//            print("\(peer.displayName) connected to session")
+//        case .connecting :
+//            print("\(peer.displayName) is attempting to connect")
+//        case .notConnected :
+//            print("\(peer.displayName) disconnected or was unable to connect")
+//        default: break
+//        }
+//    default: break
+//    }
+//    
+//}, withKey: "connectedDevicesChanged")
+//
+//// Listen to streams
+//pcm.listenOn({ event in
+//    
+//    switch event {
+//    case .receivedStream(let peer, let stream, let name):
+//        print("Recieved stream with name: \(name) from peer: \(peer.displayName)")
+//        // Do something with input stream
+//        
+//    default: break
+//    }
+//    
+//}, withKey: "streamListener")
+//
+//// Receiving resources
+//pcm.listenOn({ event in
+//    
+//    switch event {
+//    case .startedReceivingResource(let peer, let name, let progress):
+//        // Started receivng resource from peer
+//        print("Receiving resource with name: \(name) from peer: \(peer.displayName) with progress: \(progress)")
+//        
+//    case .finishedReceivingResource(let peer, let name, let url, let error):
+//        // Finished receiving resource from peer
+//        print("Finished receiving resource with name: \(name) from peer: \(peer.displayName) at url: \(url.path) with error: \(error)")
+//        
+//    default: break
+//    }
+//    
+//}, withKey: "resourceListener")
+//
+//
+//
+//// You should always stop the connection manager when you are done with it.
+//// Starting a new manager without properly stopping other managers on the same device can
+//// result in undefined behavior.
+//pcm.stop()
+//
+//
+//// TODO: - Extend service with NSNetService and Bonjour C API for manually
+////      configuring the PeerSession.
+//// TODO: - Add Testing
+//

--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -9,68 +9,102 @@
 import Foundation
 import MultipeerConnectivity
 
-/**
- Struct reperesenting a user available for mesh-networking on the PeerConnectivity framework.
- */
+/// Struct reperesenting a user available for mesh-networking on the PeerConnectivity framework.
 public struct Peer {
-    
-    /**
-     Peer connection status.
-     */
+
+    // MARK: - Nested Types -
+
+    /// Peer connection status.
     public enum Status {
-        /**
-         Represents the current user.
-         */
+
+        /// Represents the current user.
         case currentUser
-        /**
-         Represents a connected user.
-         */
+
+        /// Represent a service peer (found through browser)
+        case available
+
+        /// Represent a unavailable peer (lostPeer not received from browser)
+        case unavailable
+
+        // -
+
+        /// Represents a connected user.
         case connected
-        /**
-         Represents a connecting user.
-         */
+
+        /// Represents a connecting user.
         case connecting
-        /**
-         Represents a user not connected to the current session. Either someone that is available to be invited to the current session or someone that has lost connection to the current session.
-         */
+
+        /// Represents a user not connected to the current session.
+        /// Either someone that is available to be invited to the current session or
+        ///     someone that has lost connection to the current session.
         case notConnected
+
+        // MARK: - Initializers
+
+        init(state: MCSessionState) {
+            switch state {
+            case .notConnected: self = .notConnected
+            case .connecting: self = .connecting
+            case .connected: self = .connected
+            }
+        }
+
     }
+
+    // MARK: - Properties -
+
+    public let peerID: MCPeerID
     
-    /**
-     The peer's display name
-     */
-    public var displayName : String {
+    /// The connection status to a particular user.
+    public let status: Status
+
+    /// Service discovery informations, if peers represent service from NearbyServiceBrowser
+    public let serviceDiscoveryInfo: DiscoveryInfo?
+
+    // MARK: - Computed Properties -
+
+    /// The peer's display name
+    public var displayName: String {
         return peerID.displayName
     }
-    
-    public let peerID : MCPeerID
-    
-    /**
-     The connection status to a particular user.
-     */
-    public let status : Status
-    
-    internal init(peerID: MCPeerID, status: Status) {
+
+    // MARK: - Initializers -
+
+    internal init(peerID: MCPeerID, status: Status, info: DiscoveryInfo? = nil) {
         self.peerID = peerID
         self.status = status
+        self.serviceDiscoveryInfo = info
     }
-    
-    /**
-     Initializer for the local peer. DisplayName Must not be longer than 63 bytes in UTF8 Encoding according to the Apple documentation. ( xcdoc://?url=developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCPeerID_class/index.html#//apple_ref/swift/cl/c:objc(cs)MCPeerID )
-     */
+
+    internal init(peer: Peer, status: Status) {
+        self.status = status
+        self.peerID = peer.peerID
+        self.serviceDiscoveryInfo = peer.serviceDiscoveryInfo
+    }
+
+    /// Initializer for the local peer.
+    /// DisplayName Must not be longer than 63 bytes in UTF8 Encoding according to the Apple documentation.
+    /// [MCPeerID reference](xcdoc://?url=developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCPeerID_class/index.html#//apple_ref/swift/cl/c:objc(cs)MCPeerID)
     internal init(displayName: String) {
-        peerID = MCPeerID(displayName: displayName)
-        status = .currentUser
+        self.status = .currentUser
+        self.serviceDiscoveryInfo = nil
+        self.peerID = MCPeerID(displayName: displayName)
     }
 }
 
-extension Peer : Hashable, Equatable {
+// MARK: - Protocols
+// MARK: - Hashable, Equatable
+
+extension Peer: Hashable, Equatable {
+
     /// :nodoc:
-    public var hashValue : Int {
+    public var hashValue: Int {
         return peerID.hashValue
     }
-}
-/// :nodoc:
-public func ==(lhs: Peer, rhs: Peer) -> Bool {
-    return lhs.peerID == rhs.peerID
+
+    /// :nodoc:
+    public static func ==(lhs: Peer, rhs: Peer) -> Bool {
+        return lhs.peerID == rhs.peerID
+    }
+
 }

--- a/Sources/PeerAdvertiser.swift
+++ b/Sources/PeerAdvertiser.swift
@@ -11,14 +11,15 @@ import MultipeerConnectivity
 
 internal struct PeerAdvertiser {
     
-    fileprivate let session : PeerSession
-    fileprivate let advertiser : MCNearbyServiceAdvertiser
-    fileprivate let eventProducer : PeerAdvertiserEventProducer
+    fileprivate let session: PeerSession
+    fileprivate let advertiser: MCNearbyServiceAdvertiser
+    fileprivate let eventProducer: PeerAdvertiserEventProducer
     
-    internal init(session: PeerSession, serviceType: ServiceType, eventProducer: PeerAdvertiserEventProducer) {
+    internal init(session: PeerSession, serviceType: ServiceType,
+                  discoveryInfo info: [String : String]?, eventProducer: PeerAdvertiserEventProducer) {
         self.session = session
         self.eventProducer = eventProducer
-        advertiser = MCNearbyServiceAdvertiser(peer: session.peer.peerID, discoveryInfo: nil, serviceType: serviceType)
+        advertiser = MCNearbyServiceAdvertiser(peer: session.peer.peerID, discoveryInfo: info, serviceType: serviceType)
         advertiser.delegate = eventProducer
     }
     

--- a/Sources/PeerAdvertiserAssisstant.swift
+++ b/Sources/PeerAdvertiserAssisstant.swift
@@ -11,9 +11,9 @@ import MultipeerConnectivity
 
 internal struct PeerAdvertiserAssisstant {
     
-    fileprivate let session : PeerSession
-    fileprivate let assisstant : MCAdvertiserAssistant
-    fileprivate let eventProducer : PeerAdvertiserAssisstantEventProducer?
+    fileprivate let session: PeerSession
+    fileprivate let assisstant: MCAdvertiserAssistant
+    fileprivate let eventProducer: PeerAdvertiserAssisstantEventProducer?
     
     internal init(session: PeerSession, serviceType: ServiceType, eventProducer: PeerAdvertiserAssisstantEventProducer? = nil) {
         self.session = session

--- a/Sources/PeerAdvertiserAssisstantEventProducer.swift
+++ b/Sources/PeerAdvertiserAssisstantEventProducer.swift
@@ -17,7 +17,7 @@ internal enum PeerAdvertiserAssisstantEvent {
 
 internal class PeerAdvertiserAssisstantEventProducer: NSObject {
     
-    fileprivate let observer : Observable<PeerAdvertiserAssisstantEvent>
+    fileprivate let observer: Observable<PeerAdvertiserAssisstantEvent>
     
     internal init(observer: Observable<PeerAdvertiserAssisstantEvent>) {
         self.observer = observer

--- a/Sources/PeerAdvertiserEventProducer.swift
+++ b/Sources/PeerAdvertiserEventProducer.swift
@@ -17,7 +17,7 @@ internal enum PeerAdvertiserEvent {
 
 internal class PeerAdvertiserEventProducer: NSObject {
     
-    fileprivate let observer : Observable<PeerAdvertiserEvent>
+    fileprivate let observer: Observable<PeerAdvertiserEvent>
     
     internal init(observer: Observable<PeerAdvertiserEvent>) {
         self.observer = observer
@@ -33,10 +33,11 @@ extension PeerAdvertiserEventProducer: MCNearbyServiceAdvertiserDelegate {
         self.observer.value = event
     }
     
-    internal func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+    internal func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID,
+                             withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
         NSLog("%@", "didReceiveInvitationFromPeer \(peerID)")
         
-        let handler : ((Bool, PeerSession) -> Void) = { (accept, session) in
+        let handler: ((Bool, PeerSession) -> Void) = { (accept, session) in
             invitationHandler(accept, session.session)
         }
         

--- a/Sources/PeerBrowser.swift
+++ b/Sources/PeerBrowser.swift
@@ -9,31 +9,64 @@
 import Foundation
 import MultipeerConnectivity
 
+typealias SessionFactory = (Peer, Data?) -> PeerSession
+
 internal struct PeerBrowser {
-    
-    fileprivate let session : PeerSession
-    fileprivate let browser : MCNearbyServiceBrowser
-    fileprivate let eventProducer : PeerBrowserEventProducer
+
+    // MARK: - Properties -
+
+    fileprivate let peer: Peer?
+    fileprivate let session: PeerSession?
+
+    fileprivate var browser: MCNearbyServiceBrowser
+    fileprivate let eventProducer: PeerBrowserEventProducer
+    fileprivate let sessionFactory: SessionFactory?
+
+    // MARK: - Initializers -
     
     internal init(session: PeerSession, serviceType: ServiceType, eventProducer: PeerBrowserEventProducer) {
+        self.peer = nil
         self.session = session
+
+        self.sessionFactory = nil
         self.eventProducer = eventProducer
+
         browser = MCNearbyServiceBrowser(peer: session.peer.peerID, serviceType: serviceType)
         browser.delegate = eventProducer
     }
-    
-    internal func invitePeer(_ peer: Peer, withContext context: Data? = nil, timeout: TimeInterval = 30) {
-        browser.invitePeer(peer.peerID, to: session.session, withContext: context, timeout: timeout)
+
+    internal init(peer: Peer, serviceType: ServiceType,
+                  factory: @escaping SessionFactory, eventProducer: PeerBrowserEventProducer) {
+        self.peer = peer
+        self.session = nil
+
+        self.sessionFactory = factory
+        self.eventProducer = eventProducer
+
+        browser = MCNearbyServiceBrowser(peer: peer.peerID, serviceType: serviceType)
+        browser.delegate = eventProducer
     }
-    
+
+    // MARK: - Browser Management -
+
     internal func startBrowsing() {
         browser.delegate = eventProducer
         browser.startBrowsingForPeers()
     }
-    
+
     internal func stopBrowsing() {
         browser.stopBrowsingForPeers()
         browser.delegate = nil
     }
-    
+
+    // MARK: - Browser peer management -
+
+    internal func invitePeer(_ peer: Peer, withContext context: Data? = nil, timeout: TimeInterval = 30) throws {
+        guard let session = self.session ?? sessionFactory?(peer, context) else {
+            throw PeerConnectionManager.Error.unsupportedModeUsage
+        }
+
+        browser.invitePeer(peer.peerID, to: session.session, withContext: context, timeout: timeout)
+    }
+
 }

--- a/Sources/PeerBrowserAssisstant.swift
+++ b/Sources/PeerBrowserAssisstant.swift
@@ -11,8 +11,8 @@ import MultipeerConnectivity
 
 internal struct PeerBrowserAssisstant {
     
-    fileprivate let session : PeerSession
-    fileprivate let serviceType : ServiceType
+    fileprivate let session: PeerSession
+    fileprivate let serviceType: ServiceType
     fileprivate let eventProducer: PeerBrowserViewControllerEventProducer
     
     internal init(session: PeerSession, serviceType: ServiceType, eventProducer: PeerBrowserViewControllerEventProducer) {

--- a/Sources/PeerBrowserEventProducer.swift
+++ b/Sources/PeerBrowserEventProducer.swift
@@ -9,16 +9,18 @@
 import Foundation
 import MultipeerConnectivity
 
+public typealias DiscoveryInfo = [String: String]
+
 internal enum PeerBrowserEvent {
     case none
     case didNotStartBrowsingForPeers(Error)
-    case foundPeer(Peer)
+    case foundPeer(Peer, DiscoveryInfo?)
     case lostPeer(Peer)
 }
 
 internal class PeerBrowserEventProducer: NSObject {
     
-    fileprivate let observer : Observable<PeerBrowserEvent>
+    fileprivate let observer: Observable<PeerBrowserEvent>
     
     internal init(observer: Observable<PeerBrowserEvent>) {
         self.observer = observer
@@ -30,23 +32,24 @@ extension PeerBrowserEventProducer: MCNearbyServiceBrowserDelegate {
     internal func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
         NSLog("%@", "didNotStartBrowsingForPeers: \(error)")
         
-        let event : PeerBrowserEvent = .didNotStartBrowsingForPeers(error)
+        let event: PeerBrowserEvent = .didNotStartBrowsingForPeers(error)
         self.observer.value = event
     }
     
-    internal func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
+    internal func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID,
+                          withDiscoveryInfo info: [String: String]?) {
         NSLog("%@", "foundPeer: \(peerID)")
         
-        let peer = Peer(peerID: peerID, status: .notConnected)
-        let event : PeerBrowserEvent = .foundPeer(peer)
+        let peer = Peer(peerID: peerID, status: .available, info: info)
+        let event: PeerBrowserEvent = .foundPeer(peer, info)
         self.observer.value = event
     }
     
     internal func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
         NSLog("%@", "lostPeer: \(peerID)")
         
-        let peer = Peer(peerID: peerID, status: .notConnected)
-        let event : PeerBrowserEvent = .lostPeer(peer)
+        let peer = Peer(peerID: peerID, status: .unavailable)
+        let event: PeerBrowserEvent = .lostPeer(peer)
         self.observer.value = event
     }
 

--- a/Sources/PeerBrowserViewControllerEventProducer.swift
+++ b/Sources/PeerBrowserViewControllerEventProducer.swift
@@ -38,13 +38,13 @@ internal class PeerBrowserViewControllerEventProducer: NSObject {
 
 extension PeerBrowserViewControllerEventProducer: MCBrowserViewControllerDelegate {
 
-//    func browserViewController(browserViewController: MCBrowserViewController, shouldPresentNearbyPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) -> Bool {
+//    func browserViewController(browserViewController: MCBrowserViewController, shouldPresentNearbyPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) -> Bool {
 //        return true
 //    }
     
     internal func browserViewControllerDidFinish(_ browserViewController: MCBrowserViewController) {
         
-        let event : PeerBrowserViewControllerEvent = .didFinish
+        let event: PeerBrowserViewControllerEvent = .didFinish
         self.observer.value = event
         
         browserViewController.dismiss(animated: true, completion: nil)
@@ -52,7 +52,7 @@ extension PeerBrowserViewControllerEventProducer: MCBrowserViewControllerDelegat
     
     internal func browserViewControllerWasCancelled(_ browserViewController: MCBrowserViewController) {
         
-        let event : PeerBrowserViewControllerEvent = .wasCancelled
+        let event: PeerBrowserViewControllerEvent = .wasCancelled
         self.observer.value = event
         
         browserViewController.dismiss(animated: true, completion: nil)

--- a/Sources/PeerConnectionManager+Listener.swift
+++ b/Sources/PeerConnectionManager+Listener.swift
@@ -1,0 +1,65 @@
+//
+//  PeerConnectionManager+Listener.swift
+//  PeerConnectivity
+//
+//  Created by Julien Di Marco on 25/10/2018.
+//  Copyright © 2018 Reid Chatham. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Manager listener management -
+
+public extension PeerConnectionManager {
+
+    /// Takes a `PeerConnectionEventListener` to respond to events.
+    ///
+    /// - parameter listener: Takes a `PeerConnectionEventListener`.
+    /// - parameter performListenerInBackground: Default is `false`. Set to `true` to perform the listener asyncronously.
+    /// - parameter withKey: The key with which to associate the listener.
+
+    public func listenOn(_ listener: @escaping PeerConnectionEventListener,
+                         performListenerInBackground background: Bool = false, withKey key: String) {
+
+        switch background {
+        case true:
+            responder.addListener(listener, forKey: key)
+        case false:
+            responder.addListener({ (event) in
+                DispatchQueue.main.async(execute: {
+                    listener(event)
+                })
+            }, forKey: key)
+        }
+    }
+
+    /// Takes a key to register the callback and calls the listener when an event is recieved and also passes back the `Peer` that sent it.
+    ///
+    /// - parameter key: `String` key with which to keep track of the listener for later removal.
+    /// - parameter listener: Callback that returns the event info and the `Peer` whenever an event is received.
+
+    public func observeEventListenerForKey(_ key: String, listener: @escaping ([String: Any], PeerSession, Peer) -> Void) {
+        responder.addListener({ (event) in
+            switch event {
+            case .receivedEvent(let session, let peer, let eventInfo):
+                listener(eventInfo, session, peer)
+            default: break
+            }
+        }, forKey: key)
+    }
+
+
+    /// Remove a listener associated with a specified key.
+    ///
+    /// - parameter key: The key with which to attempt to find and remove a listener with.
+
+    public func removeListenerForKey(_ key: String) {
+        responder.removeListenerForKey(key)
+    }
+
+    /// Remove all listeners.
+    public func removeAllListeners() {
+        responder.removeAllListeners()
+    }
+
+}

--- a/Sources/PeerConnectionManager+Peer.swift
+++ b/Sources/PeerConnectionManager+Peer.swift
@@ -1,0 +1,82 @@
+//
+//  PeerConnectionManager+Peer.swift
+//  PeerConnectivity
+//
+//  Created by Julien Di Marco on 25/10/2018.
+//  Copyright © 2018 Reid Chatham. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Peer Manipulation (invitation / transmission) -
+
+public extension PeerConnectionManager {
+    // Use to invite peers that have been found locally to join a MultipeerConnectivity session.
+    //
+    // - parameter peer: `Peer` object to invite to current session.
+    // - parameter withContext: `Data` object associated with the invitation.
+    // - parameter timeout: Time interval until the invitation expires.
+
+    public func invitePeer(_ peer: Peer, withContext context: Data? = nil, timeout: TimeInterval = 30) throws {
+        try browser?.invitePeer(peer, withContext: context, timeout: timeout)
+    }
+
+    // Send data to connected users. If no peer is specified it broadcasts to all users on a current session.
+    //
+    // - parameter data: Data to be sent to specified peers.
+    // - parameter toPeers: Specified `Peer` objects to send data.
+
+    public func sendData(_ data: Data, toPeers peers: [Peer] = []) {
+        session.sendData(data, toPeers: peers)
+    }
+
+    // Send events to connected users. Encoded as Data using the NSKeyedArchiver.
+    //   If no peer is specified it broadcasts to all users on a current session.
+    //
+    // - parameter eventInfo: Dictionary of Any data which is encoded with
+    //    the NSKeyedArchiver and passed to the specified peers.
+    // - parameter toPeers: Specified `Peer` objects to send event.
+
+    public func sendEvent(_ eventInfo: [String:Any], toPeers peers: [Peer] = []) {
+        let eventData = NSKeyedArchiver.archivedData(withRootObject: eventInfo)
+        session.sendData(eventData, toPeers: peers)
+    }
+
+    // Send a data stream to a connected user. This method throws an error if the stream cannot be established.
+    //    This method returns the NSOutputStream with which you can send events to the connected users.
+    //
+    // - parameter streamName: The name of the stream to be established between two users.
+    // - parameter toPeer: The peer with which to start a data stream
+    //
+    // - Throws: Propagates errors thrown by Apple's MultipeerConnectivity framework.
+    //
+    // - Returns: The OutputStream for sending information to the specified `Peer` object.
+
+    public func sendDataStream(streamName name: String, toPeer peer: Peer) throws -> OutputStream {
+        do { return try session.sendDataStream(name, toPeer: peer) }
+        catch let error { throw error }
+    }
+
+    // Send a resource with a specified url for retrieval on a connected device.
+    //    This method can send a resource to multiple peers and returns an Progress associated with each Peer.
+    //    This method takes an error completion handler if the resource fails to send.
+    //
+    // - parameter resourceURL: The url that the resource will be passed with for retrieval.
+    // - parameter withName: The name with which the progress is associated with.
+    // - parameter toPeers: The specified peers for the resource to be sent to.
+    // - parameter withCompletionHandler: the completion handler called when an error is thrown sending a resource.
+    //
+    // - Returns: A dictionary of optional Progress associated with each peer that the resource was sent to.
+
+    public func sendResourceAtURL(_ resourceURL: URL, withName name: String, toPeers peers: [Peer] = [],
+                                  withCompletionHandler completion: ((Swift.Error?) -> Void)? ) -> [Peer:Progress?] {
+
+        var progress: [Peer: Progress?] = [:]
+        let peers = (peers.isEmpty) ? self.connectedPeers : peers
+        for peer in peers {
+            progress[peer] = session.sendResourceAtURL(resourceURL, withName: name, toPeer: peer,
+                                                       withCompletionHandler: completion)
+        }
+        return progress
+    }
+}

--- a/Sources/PeerConnectionManager.swift
+++ b/Sources/PeerConnectionManager.swift
@@ -6,144 +6,214 @@
 //  Copyright © 2015 Reid Chatham. All rights reserved.
 //
 
-import UIKit
+import Foundation
+import MultipeerConnectivity
 
-/**
- The service type describing the channel over which connections are made.
- */
+/// The service type describing the channel over which connections are made.
 public typealias ServiceType = String
 
-/**
- Struct representing specified keys for configuring a connection manager.
- */
+/// Struct representing specified keys for configuring a connection manager.
 public struct PeerConnectivityKeys {
     static fileprivate let CertificateListener = "CertificateRecievedListener"
 }
 
-/**
- Enum represeting available connection types. `.automatic`, `.inviteOnly`, `.custom`.
- */
-public enum PeerConnectionType : Int {
-    /**
-     Connection type where all available devices attempt to connect automatically.
-     */
+/// Enum represeting available connection types. `.automatic`, `.inviteOnly`, `.custom`.
+public enum PeerConnectionType: Int {
+
+    /// Connection type where all available devices attempt to connect automatically.
     case automatic = 0
-    /**
-     Connection type providing the browser view controller and advertiser assistant giving the user the ability to handle connections with nearby peers.
-     */
+
+    /// Connection type providing the browser view controller and advertiser assistant
+    /// giving the user the ability to handle connections with nearby peers.
     case inviteOnly
-    /**
-     No default connection implementation is given allowing full control for determining approval of connections using custom algorithms.
-     */
+
+    // No default connection implementation is given allowing full control
+    //  for determining approval of connections using custom algorithms.
     case custom
 }
 
-/**
- Functional wrapper for Apple's MultipeerConnectivity framework.
- 
- Initialize a PeerConnectionManager to enable mesh-networking over bluetooth and wifi when available. Configure the networking protocol of the session and then start to begin connecting to nearby peers.
- */
+public enum PeerManagerMode: Int {
+
+    /// use `session` and `advertiser` only, advertise itself and wait for invitation from `browsers`
+    case master = 0
+
+    /// use `session` and `browser` only, once connected to an advertiser browsing is disabled
+    case slave
+
+    /// use `session` and `advertiser` together similar to `master` mode
+    /// However, browser is also started and invite similar node w/ matching 'serviceType'
+    /// usig .custom connectionType you can still manage invitation/acceptation
+    /// however in this mode browser will instance new `session` for each new node discovered
+    case node
+
+}
+
+/// Functional wrapper for Apple's MultipeerConnectivity framework.
+///
+/// Initialize a PeerConnectionManager to enable mesh-networking over bluetooth and wifi when available.
+///  Configure the networking protocol of the session and then start to begin connecting to nearby peers.
 public class PeerConnectionManager {
     
-    // MARK: Static
-    /**
-     Access to shared connection managers by their service type.
-     */
-    public fileprivate(set) static var shared : [ServiceType:PeerConnectionManager] = [:]
-    
-    // MARK: Properties
-    /**
-     The connection type for the connection manager. (ex. `.automatic`, `.inviteOnly`, `.custom`)
-     */
-    public let connectionType : PeerConnectionType
-    
-    /**
-     Access to the local peer representing the user.
-     */
-    public let peer : Peer
-    
-    /**
-     Returns the peers that are connected on the current session.
-     */
-    public var connectedPeers : [Peer] {
+    // MARK: - Static Properties -
+
+    /// Access to shared connection managers by their service type.
+    public fileprivate(set) static var shared: [ServiceType: PeerConnectionManager] = [:]
+
+    // MARK: - Nested Properties -
+
+    enum Error: Swift.Error {
+        case unsupportedModeUsage
+    }
+
+    // MARK: - Properties -
+
+    /// Access to the local peer representing the user.
+    public let peer: Peer
+
+    /// The manager mode for the connection manager. instance 'advertiser' or 'assistant' relatively
+    public let managerMode: PeerManagerMode
+
+    /// The connection type for the connection manager. (ex. `.automatic`, `.inviteOnly`, `.custom`)
+    public let connectionType: PeerConnectionType
+
+    /// an array of [ SecIdentityRef, [ zero or more additional certs ] ].
+    public var sessionSecurityIdentity: [Any]? = nil
+    public var sessionEncryptionPreference: MCEncryptionPreference = .optional
+
+    // MARK: - Computed Properties -
+
+    /// Returns the peers that are connected on the current session.
+    public var connectedPeers: [Peer] {
         return session.connectedPeers
     }
-    
-    /**
-     Nearby peers available for connecting. 
-     
-     - Note: Can be observed by listening for PeerConnectivityEvent.nearbyPeersChanged(foundPeers:).
-     */
+
+    public var connectedServicePeers: [Peer] {
+        return servicesSessions.reduce([], { (peers, serviceSession) -> [Peer] in
+            return Array(Set(peers + serviceSession.connectedPeers))
+        })
+    }
+
+    /// Nearby peers available for connecting.
+    ///
+    /// - Note: Can be observed by listening for PeerConnectivityEvent.nearbyPeersChanged(foundPeers:).
     public fileprivate(set) var foundPeers: [Peer] = [] {
         didSet {
             observer.value = .nearbyPeersChanged(foundPeers: foundPeers)
         }
     }
-    
-    
-    // Private
-    fileprivate let serviceType : ServiceType
-    
+
+    // MARK: - Private Properties
+
+    /// This will be the `advertiser` session in `.master` and `.none` mode
+    /// however it'll be the `browser` session in `.slave` mode
+    public let session: PeerSession
+    public var servicesSessions: [PeerSession] = []
+
+    fileprivate let serviceType: ServiceType
+    fileprivate let serviceDiscoveryInfo: [String: String]?
+
+    internal var browser: PeerBrowser?
+    lazy fileprivate var browserAssisstant: PeerBrowserAssisstant? = {
+        return PeerBrowserAssisstant(session: session, serviceType: serviceType,
+                                     eventProducer: browserViewControllerEventProducer)
+    }()
+
+    fileprivate let advertiser: PeerAdvertiser
+    lazy fileprivate var advertiserAssisstant: PeerAdvertiserAssisstant? = {
+        return PeerAdvertiserAssisstant(session: session, serviceType: serviceType,
+                                        eventProducer: advertiserAssisstantEventProducer)
+    }()
+
+    // MARK: - Event Observable Properties
+
+    internal let responder: PeerConnectionResponder
     fileprivate let observer = MultiObservable<PeerConnectionEvent>(.ready)
-    
-    fileprivate let sessionObserver = Observable<PeerSessionEvent>(.none)
+
+    fileprivate let sessionObserver = Observable<SessionEventContainer>((nil, .none))
     fileprivate let browserObserver = Observable<PeerBrowserEvent>(.none)
-    fileprivate let browserViewControllerObserver = Observable<PeerBrowserViewControllerEvent>(.none)
     fileprivate let advertiserObserver = Observable<PeerAdvertiserEvent>(.none)
+
+    /// - Theses are interfaces/encapsulated controllers from apple
     fileprivate let advertiserAssisstantObserver = Observable<PeerAdvertiserAssisstantEvent>(.none)
-    
-    fileprivate let sessionEventProducer : PeerSessionEventProducer
-    fileprivate let browserEventProducer : PeerBrowserEventProducer
-    fileprivate let browserViewControllerEventProducer : PeerBrowserViewControllerEventProducer
-    fileprivate let advertiserEventProducer : PeerAdvertiserEventProducer
-    fileprivate let advertiserAssisstantEventProducer : PeerAdvertiserAssisstantEventProducer
-    
-    fileprivate let session : PeerSession
-    fileprivate let browser : PeerBrowser
-    fileprivate let browserAssisstant : PeerBrowserAssisstant
-    fileprivate let advertiser : PeerAdvertiser
-    fileprivate let advertiserAssisstant : PeerAdvertiserAssisstant
-    
-    fileprivate let responder : PeerConnectionResponder
-    
-    
-    // MARK: Initializer
-    /**
-     Initializer for a connection manager. Requires the requested service type. If the connectionType and displayName are not specified the connection manager defaults to .Automatic and using the local device name.
-     
-     - parameter serviceType: The requested service type describing the channel on which peers are able to connect.
-     - parameter connectionType: Takes a PeerConnectionType case determining the default behavior of the framework.
-     - parameter displayName: The local user's display name to other peers.
-     
-     - Returns: A fully initialized `PeerConnectionManager`.
-     */
+    fileprivate let browserViewControllerObserver = Observable<PeerBrowserViewControllerEvent>(.none)
+
+    // MARK: - Event Producer Properties
+
+    fileprivate let sessionEventProducer: PeerSessionEventProducer
+    fileprivate let browserEventProducer: PeerBrowserEventProducer
+    fileprivate let advertiserEventProducer: PeerAdvertiserEventProducer
+
+    fileprivate let advertiserAssisstantEventProducer: PeerAdvertiserAssisstantEventProducer
+
+    fileprivate let browserViewControllerEventProducer: PeerBrowserViewControllerEventProducer
+
+    // MARK: - Initializer -
+
+    /// Initializer for a connection manager. Requires the requested service type.
+    ///     If the connectionType and displayName are not specified the connection manager \
+    ///     defaults to .Automatic and using the local device name.
+    ///
+    /// - parameter serviceType: The requested service type describing the channel on which peers are able to connect.
+    /// - parameter connectionType: Takes a PeerConnectionType case determining the default behavior of the framework.
+    /// - parameter displayName: The local user's display name to other peers.
+    ///
+    /// - Returns: A fully initialized `PeerConnectionManager`.
     public init(serviceType: ServiceType,
-                connectionType: PeerConnectionType = .automatic,
-                displayName: String = UIDevice.current.name) {
-        
-        self.connectionType = connectionType
+                displayName: String = UIDevice.current.name,
+                serviceDiscoveryInfo: [String: String]? = nil,
+                connectionType: PeerConnectionType = .automatic, managerMode: PeerManagerMode = .master,
+                securityIdentity identity: [Any]?, encryptionPreference: MCEncryptionPreference) {
+
         self.serviceType = serviceType
+        self.serviceDiscoveryInfo = serviceDiscoveryInfo
+
+        self.managerMode = managerMode
+        self.connectionType = connectionType
+
+        self.sessionSecurityIdentity = identity
+        self.sessionEncryptionPreference = encryptionPreference
+
         self.peer = Peer(displayName: displayName)
-        
+
+        // - Producers, Observers && Responders
+
         sessionEventProducer = PeerSessionEventProducer(observer: sessionObserver)
         browserEventProducer = PeerBrowserEventProducer(observer: browserObserver)
-        browserViewControllerEventProducer = PeerBrowserViewControllerEventProducer(observer: browserViewControllerObserver)
         advertiserEventProducer = PeerAdvertiserEventProducer(observer: advertiserObserver)
+
         advertiserAssisstantEventProducer = PeerAdvertiserAssisstantEventProducer(observer: advertiserAssisstantObserver)
-        
-        session = PeerSession(peer: peer, eventProducer: sessionEventProducer)
-        browser = PeerBrowser(session: session, serviceType: serviceType, eventProducer: browserEventProducer)
-        browserAssisstant = PeerBrowserAssisstant(session: session, serviceType: serviceType, eventProducer: browserViewControllerEventProducer)
-        advertiser = PeerAdvertiser(session: session, serviceType: serviceType, eventProducer: advertiserEventProducer)
-        advertiserAssisstant = PeerAdvertiserAssisstant(session: session, serviceType: serviceType, eventProducer: advertiserAssisstantEventProducer)
-        
+        browserViewControllerEventProducer = PeerBrowserViewControllerEventProducer(observer: browserViewControllerObserver)
+
         responder = PeerConnectionResponder(observer: observer)
-        
+
+        // - Session, Advertiser, Browser
+
+        session = PeerSession(peer: peer, eventProducer: sessionEventProducer,
+                              securityIdentity: sessionSecurityIdentity, encryptionPreference: encryptionPreference)
+        advertiser = PeerAdvertiser(session: session, serviceType: serviceType,
+                                    discoveryInfo: serviceDiscoveryInfo, eventProducer: advertiserEventProducer)
+
+        switch managerMode {
+        case .node:
+            browser = PeerBrowser(peer: peer, serviceType: serviceType, factory: { (browserPeer, _) -> PeerSession in
+                let nodeServiceSession = PeerSession(peer: self.peer, servicePeer: browserPeer,
+                                                     eventProducer: self.sessionEventProducer,
+                                                     securityIdentity: self.sessionSecurityIdentity,
+                                                     encryptionPreference: self.sessionEncryptionPreference)
+                self.servicesSessions += [nodeServiceSession]
+                return nodeServiceSession
+            }, eventProducer: browserEventProducer)
+        case .slave:
+            browser = PeerBrowser(session: session, serviceType: serviceType, eventProducer: browserEventProducer)
+        default: break
+        }
+
+        // - Default responder listener
+
         // Currently checking security certificates is not yet supported.
         responder.addListener({ (event) in
             switch event {
-            case .receivedCertificate(peer: _, certificate: _, handler: let handler):
-                //print("PeerConnectionManager: listenOn: certificateReceived")
+            case .receivedCertificate(session: _, peer: _, certificate: _, handler: let handler):
                 handler(true)
             default: break
             }
@@ -153,8 +223,8 @@ public class PeerConnectionManager {
         if let existing = PeerConnectionManager.shared[serviceType] {
             existing.stop()
             existing.removeAllListeners()
-            PeerConnectionManager.shared[serviceType] = self
         }
+        PeerConnectionManager.shared[serviceType] = self
     }
     
     deinit {
@@ -166,20 +236,98 @@ public class PeerConnectionManager {
     }
 }
 
+// MARK: - PeerConnectionManager business functions -
+
 extension PeerConnectionManager {
-    // MARK: Using the PeerConnectionManager
-    
-    /**
-     Start the connection manager with optional completion. Calling this initiates browsing and advertising using the specified connection type.
-     
-     - parameter completion: Called once session is initialized. Default is `nil`.
-     */
-    public func start(_ completion: (() -> Void)? = nil) {
+
+    /// Start the connection manager with optional completion. Calling this initiates browsing and advertising using the specified connection type.
+    ///
+    /// - parameter completion: Called once session is initialized. Default is `nil`.
+    public func start(_ completion: (() -> Void)? = nil) throws {
+        configureObserverResponseEventDispatch()
+        configureManagerPeerObservers()
+        try configureDefaultConnectionTypeBehavior()
+
+        session.startSession()
+        browser?.startBrowsing()
+
+        advertiser.stopAdvertising()
+        advertiser.startAdvertising()
         
+        observer.value = .started
+        completion?()
+    }
+
+    // Refresh the current session.
+    // This call disconnects the user from the current session and then restarts the session \
+    //  with completion maintaing the current sessions configuration.
+    //
+    // - parameter completion: Completion handler called after the session has completed refreshing.
+    public func refresh(_ completion: (() -> Void)? = nil) throws {
+        stop()
+        try start(completion)
+    }
+
+    /// Stop the current connection manager from listening to delegate callbacks and disconnects from the current session.
+    public func stop() {
+        session.stopSession()
+        servicesSessions.forEach { $0.stopSession() }
+        servicesSessions = []
+
+        browser?.stopBrowsing()
+        advertiser.stopAdvertising()
+        advertiserAssisstant?.stopAdvertisingAssisstant()
+
+        observer.value = .ended
+
+        foundPeers = []
+        sessionObserver.observers = []
+        browserObserver.observers = []
+        advertiserObserver.observers = []
+        advertiserAssisstantObserver.observers = []
+        browserViewControllerObserver.observers = []
+
+        sessionObserver.value = (nil, .none)
+        browserObserver.value = .none
+        advertiserObserver.value = .none
+        advertiserAssisstantObserver.value = .none
+        browserViewControllerObserver.value = .none
+
+        observer.value = .ready
+    }
+
+    // MARK: - Private Configurations
+
+    private func devicesConnectionChange(peer: Peer, session: PeerSession) {
+        if session != self.session && peer == session.servicePeer && peer.status == .notConnected {
+            let lostServicesSessions = servicesSessions.filter({ $0 == session })
+
+            lostServicesSessions.forEach({ $0.stopSession() })
+            servicesSessions = Array(Set(servicesSessions).subtracting(lostServicesSessions))
+
+            if let servicePeerIndex = foundPeers.firstIndex(of: peer) {
+                let servicePeer = foundPeers[servicePeerIndex]
+                foundPeers[servicePeerIndex] = Peer(peer: servicePeer, status: .unavailable)
+            }
+        }
+
+        guard session.isDistantServiceSession == false || peer == session.servicePeer else {
+            print("MultipeerConnectivity: distant service slave, other device connection: \(peer)")
+            return
+        }
+
+        // ignore this because user wants to knows services connecti on events (knows when he's connected to a distant service
+        //guard let connectedPeers = self?.connectedPeers else { break }
+        observer.value = .devicesChanged(session: session, peer: peer, connectedPeers: connectedPeers)
+    }
+
+    /// observe evevents from multiple observer and dispatch them to a single `observer`
+    ///    `browserObserver`, `advertiserObserver`, `sessionObserver` -> `observer` -> `responder`
+    private func configureObserverResponseEventDispatch() {
         browserObserver.addObserver { [weak self] event in
             switch event {
-            case .foundPeer(let peer):
-                self?.observer.value = .foundPeer(peer: peer)
+            case .foundPeer(let peer, let info):
+                self?.observer.value = .foundPeer(peer: peer, info: info)
             case .lostPeer(let peer):
                 self?.observer.value = .lostPeer(peer: peer)
             case .didNotStartBrowsingForPeers(let error):
@@ -187,12 +335,11 @@ extension PeerConnectionManager {
             default: break
             }
         }
-        
+
         advertiserObserver.addObserver { [weak self] event in
             switch event {
             case.didReceiveInvitationFromPeer(peer: let peer, withContext: let context, invitationHandler: let invite):
-                let invitationReceiver = {
-                    [weak self] (accept: Bool) -> Void in
+                let invitationReceiver = { [weak self] (accept: Bool) -> Void in
                     guard let session = self?.session else { return }
                     invite(accept, session)
                 }
@@ -202,33 +349,41 @@ extension PeerConnectionManager {
             default: break
             }
         }
-        
-        sessionObserver.addObserver { [weak self] event in
+
+        sessionObserver.addObserver { [weak self] eventContainer in
+            let event = eventContainer.event
+            let matchingSession = self?.servicesSessions.first(where: { $0 == eventContainer.session })
+
+            guard let session = matchingSession ?? eventContainer.session else {
+                return
+            }
+
             switch event {
             case .devicesChanged(peer: let peer):
-                guard let connectedPeers = self?.connectedPeers else { break }
-                self?.observer.value = .devicesChanged(peer: peer, connectedPeers: connectedPeers)
+                self?.devicesConnectionChange(peer: peer, session: session)
             case .didReceiveData(peer: let peer, data: let data):
-                self?.observer.value = .receivedData(peer: peer, data: data)
+                self?.observer.value = .receivedData(session: session, peer: peer, data: data)
                 guard let eventInfo = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String:Any] else { return }
-                self?.observer.value = .receivedEvent(peer: peer, eventInfo: eventInfo)
+                self?.observer.value = .receivedEvent(session: session, peer: peer, eventInfo: eventInfo)
             case .didReceiveCertificate(peer: let peer, certificate: let certificate, handler: let handler):
-                self?.observer.value = .receivedCertificate(peer: peer, certificate: certificate, handler: handler)
+                self?.observer.value = .receivedCertificate(session: session, peer: peer, certificate: certificate, handler: handler)
             case .didReceiveStream(peer: let peer, stream: let stream, name: let name):
-                self?.observer.value = .receivedStream(peer: peer, stream: stream, name: name)
+                self?.observer.value = .receivedStream(session: session, peer: peer, stream: stream, name: name)
             case .startedReceivingResource(peer: let peer, name: let name, progress: let progress):
-                self?.observer.value = .startedReceivingResource(peer: peer, name: name, progress: progress)
+                self?.observer.value = .startedReceivingResource(session: session, peer: peer, name: name, progress: progress)
             case .finishedReceivingResource(peer: let peer, name: let name, url: let url, error: let error):
-                self?.observer.value = .finishedReceivingResource(peer: peer, name: name, url: url, error: error)
+                self?.observer.value = .finishedReceivingResource(session: session, peer: peer, name: name, url: url, error: error)
             default: break
             }
         }
-        
+    }
+
+    private func configureManagerPeerObservers() {
         browserObserver.addObserver { [weak self] event in
             DispatchQueue.main.async {
                 switch event {
-                case .foundPeer(let peer):
-                    guard let peers = self?.foundPeers , !peers.contains(peer) else { break }
+                case .foundPeer(let peer, _):
+                    guard let peers = self?.foundPeers, !peers.contains(peer) else { break }
                     self?.foundPeers.append(peer)
                 case .lostPeer(let peer):
                     guard let index = self?.foundPeers.index(of: peer) else { break }
@@ -237,30 +392,37 @@ extension PeerConnectionManager {
                 }
             }
         }
-        
-        sessionObserver.addObserver { [weak self] event in
-            DispatchQueue.main.async {
-                guard let peerCount = self?.connectedPeers.count else { return }
-                
-                switch event {
-                case .devicesChanged(peer: let peer) where peerCount <= 0 :
-                    switch peer.status {
-                    case .notConnected:
-                        self?.refresh()
-                    default: break
-                    }
-                default: break
-                }
-            }
-        }
-        
+
+        /// here we could potentially restart the advertiser in `master` mode (if stopped)
+        /// or                        restart the browser in `slave` mode (if stopped)
+        /// however restarting everything, i don't really see the point, you've got no-one in your session
+        /// isn't an issue if you're still advertising
+//        sessionObserver.addObserver { [weak self] event in
+//            DispatchQueue.main.async {
+//                guard let peerCount = self?.connectedPeers.count,
+//                    let peerSession = event.0, peerSession == self?.session else { return }
+//
+//                switch event.1 {
+//                case .devicesChanged(peer: let peer) where peerCount <= 0 :
+//                    switch peer.status {
+//                    case .notConnected:
+//                        try? self?.refresh()
+//                    default: break
+//                    }
+//                default: break
+//                }
+//            }
+//        }
+    }
+
+    private func configureDefaultConnectionTypeBehavior() throws {
         switch connectionType {
         case .automatic:
             browserObserver.addObserver { [unowned self] event in
                 DispatchQueue.main.async {
                     switch event {
-                    case .foundPeer(let peer):
-                        self.browser.invitePeer(peer)
+                    case .foundPeer(let peer, _):
+                        try? self.browser?.invitePeer(peer)
                     default: break
                     }
                 }
@@ -275,206 +437,44 @@ extension PeerConnectionManager {
                     }
                 }
             }
+
         case .inviteOnly:
-            advertiserAssisstant.startAdvertisingAssisstant()
+            guard managerMode != .slave else {
+                throw Error.unsupportedModeUsage
+            }
+
+            advertiserAssisstant?.startAdvertisingAssisstant()
+
         case .custom: break
         }
-        
-        session.startSession()
-        browser.startBrowsing()
-        advertiser.startAdvertising()
-        
-        observer.value = .started
-        completion?()
+    }
+
+    // MARK: - Browser session management
+
+    /// Close session for browsing peers to invite.
+    public func closeSession() {
+        browser?.stopBrowsing()
     }
     
-    /**
-     Returns a browser view controller if the connectionType was set to `.InviteOnly` or returns `nil` if not.
-     
-     - parameter callback: Events sent back with cases `.DidFinish` and `.DidCancel`.
-     
-     - Returns: A browser view controller for inviting available peers nearby if connection type is `.InviteOnly` or `nil` otherwise.
-     */
-    public func browserViewController(_ callback: @escaping (PeerBrowserViewControllerEvent)->Void) -> UIViewController? {
+    /// Open session for browsing peers to invite.
+    public func openSession() {
+        browser?.startBrowsing()
+    }
+
+    // Returns a browser view controller if the connectionType was set to `.InviteOnly` or returns `nil` if not.
+    //
+    // - parameter callback: Events sent back with cases `.DidFinish` and `.DidCancel`.
+    //
+    // - Returns: A browser view controller for inviting available peers nearby if connection type is `.InviteOnly` or `nil` otherwise.
+
+    public func browserViewController(_ callback: @escaping (PeerBrowserViewControllerEvent) -> Void) -> UIViewController? {
         browserViewControllerObserver.addObserver { callback($0) }
         switch connectionType {
-        case .inviteOnly: return browserAssisstant.peerBrowserViewController()
+        case .inviteOnly: return browserAssisstant?.peerBrowserViewController()
         default: return nil
         }
     }
-    
-    /**
-     Use to invite peers that have been found locally to join a MultipeerConnectivity session.
-     
-     - parameter peer: `Peer` object to invite to current session.
-     - parameter withContext: `Data` object associated with the invitation.
-     - parameter timeout: Time interval until the invitation expires.
-     */
-    public func invitePeer(_ peer: Peer, withContext context: Data? = nil, timeout: TimeInterval = 30) {
-        browser.invitePeer(peer, withContext: context, timeout: timeout)
-    }
-    
-    /**
-     Send data to connected users. If no peer is specified it broadcasts to all users on a current session.
-     
-     - parameter data: Data to be sent to specified peers.
-     - parameter toPeers: Specified `Peer` objects to send data.
-     */
-    public func sendData(_ data: Data, toPeers peers: [Peer] = []) {
-        session.sendData(data, toPeers: peers)
-    }
-    
-    /**
-     Send events to connected users. Encoded as Data using the NSKeyedArchiver. If no peer is specified it broadcasts to all users on a current session.
-     
-     - parameter eventInfo: Dictionary of Any data which is encoded with the NSKeyedArchiver and passed to the specified peers.
-     - parameter toPeers: Specified `Peer` objects to send event.
-     */
-    public func sendEvent(_ eventInfo: [String:Any], toPeers peers: [Peer] = []) {
-        let eventData = NSKeyedArchiver.archivedData(withRootObject: eventInfo)
-        session.sendData(eventData, toPeers: peers)
-    }
-    
-    /**
-     Send a data stream to a connected user. This method throws an error if the stream cannot be established. This method returns the NSOutputStream with which you can send events to the connected users.
-     
-     - parameter streamName: The name of the stream to be established between two users.
-     - parameter toPeer: The peer with which to start a data stream
-     
-     - Throws: Propagates errors thrown by Apple's MultipeerConnectivity framework.
-     
-     - Returns: The OutputStream for sending information to the specified `Peer` object.
-     */
-    public func sendDataStream(streamName name: String, toPeer peer: Peer) throws -> OutputStream {
-        do { return try session.sendDataStream(name, toPeer: peer) }
-        catch let error { throw error }
-    }
-    
-    /**
-     Send a resource with a specified url for retrieval on a connected device. This method can send a resource to multiple peers and returns an Progress associated with each Peer. This method takes an error completion handler if the resource fails to send.
-     
-     - parameter resourceURL: The url that the resource will be passed with for retrieval.
-     - parameter withName: The name with which the progress is associated with.
-     - parameter toPeers: The specified peers for the resource to be sent to.
-     - parameter withCompletionHandler: the completion handler called when an error is thrown sending a resource.
-     
-     - Returns: A dictionary of optional Progress associated with each peer that the resource was sent to.
-     */
-    public func sendResourceAtURL(_ resourceURL: URL, withName name: String, toPeers peers: [Peer] = [], withCompletionHandler completion: ((Error?) -> Void)? ) -> [Peer:Progress?] {
-        
-        var progress : [Peer:Progress?] = [:]
-        let peers = (peers.isEmpty) ? self.connectedPeers : peers
-        for peer in peers {
-            progress[peer] = session.sendResourceAtURL(resourceURL, withName: name, toPeer: peer, withCompletionHandler: completion)
-        }
-        return progress
-    }
-    
-    /**
-     Refresh the current session. This call disconnects the user from the current session and then restarts the session with completion maintaing the current sessions configuration.
-     
-     - parameter completion: Completion handler called after the session has completed refreshing.
-     */
-    public func refresh(_ completion: (() -> Void)? = nil) {
-        stop()
-        start(completion)
-    }
-    
-    /**
-     Stop the current connection manager from listening to delegate callbacks and disconnects from the current session.
-     */
-    public func stop() {
-        observer.value = .ended
-        
-        session.stopSession()
-        browser.stopBrowsing()
-        advertiser.stopAdvertising()
-        advertiserAssisstant.stopAdvertisingAssisstant()
-        foundPeers = []
-        
-        sessionObserver.observers = []
-        browserObserver.observers = []
-        advertiserObserver.observers = []
-        advertiserAssisstantObserver.observers = []
-        browserViewControllerObserver.observers = []
-        
-        sessionObserver.value = .none
-        browserObserver.value = .none
-        advertiserObserver.value = .none
-        advertiserAssisstantObserver.value = .none
-        browserViewControllerObserver.value = .none
-        
-        observer.value = .ready
-    }
-    
-    /**
-     Close session for browsing peers to invite.
-     */
-    public func closeSession() {
-        browser.stopBrowsing()
-    }
-    
-    /**
-     Open session for browsing peers to invite.
-     */
-    public func openSession() {
-        browser.startBrowsing()
-    }
+
 }
 
-extension PeerConnectionManager {
-    // MARK: Listening to PeerConnectivity generated events
-    
-    /**
-     Takes a `PeerConnectionEventListener` to respond to events.
-     
-     - parameter listener: Takes a `PeerConnectionEventListener`.
-     - parameter performListenerInBackground: Default is `false`. Set to `true` to perform the listener asyncronously.
-     - parameter withKey: The key with which to associate the listener.
-     */
-    public func listenOn(_ listener: @escaping PeerConnectionEventListener, performListenerInBackground background: Bool = false, withKey key: String) {
-        
-        switch background {
-        case true:
-            responder.addListener(listener, forKey: key)
-        case false:
-            responder.addListener({ (event) in
-                DispatchQueue.main.async(execute: { 
-                    listener(event)
-                })
-            }, forKey: key)
-        }
-    }
-    
-    /**
-     Takes a key to register the callback and calls the listener when an event is recieved and also passes back the `Peer` that sent it.
-     
-     - parameter key: `String` key with which to keep track of the listener for later removal.
-     - parameter listener: Callback that returns the event info and the `Peer` whenever an event is received.
-     */
-    public func observeEventListenerForKey(_ key: String, listener: @escaping ([String:Any], Peer)->Void) {
-        responder.addListener({ (event) in
-            switch event {
-            case .receivedEvent(let peer, let eventInfo):
-                listener(eventInfo, peer)
-            default: break
-            }
-        }, forKey: key)
-    }
-    
-    /**
-     Remove a listener associated with a specified key.
-     
-     - parameter key: The key with which to attempt to find and remove a listener with.
-     */
-    public func removeListenerForKey(_ key: String) {
-        responder.removeListenerForKey(key)
-    }
-    
-    /**
-     Remove all listeners.
-     */
-    public func removeAllListeners() {
-        responder.removeAllListeners()
-    }
-}
+

--- a/Sources/PeerConnectionResponder.swift
+++ b/Sources/PeerConnectionResponder.swift
@@ -8,88 +8,84 @@
 
 import Foundation
 
-/**
- Network events that can be responded to via PeerConnectivity.
- */
+/// Network events that can be responded to via PeerConnectivity.
 public enum PeerConnectionEvent {
-    /** 
-     Event sent when the `PeerConnectionManager` is ready to start.
-     */
+
+    /// Event sent when the `PeerConnectionManager` is ready to start.
     case ready
-    /**
-     Signals the `PeerConnectionManager` was started succesfully.
-     */
+
+    /// Signals the `PeerConnectionManager` was started succesfully.
     case started
-    /**
-     Devices changed event which returns the `Peer` that changed along with the connected `Peer`s. Check the passed `Peer`'s `Status` to see what changed.
-     */
-    case devicesChanged(peer: Peer, connectedPeers: [Peer])
-    /**
-     Data received from `Peer`.
-     */
-    case receivedData(peer: Peer, data: Data)
-    /**
-     Event received from `Peer`.
-     */
-    case receivedEvent(peer: Peer, eventInfo: [String:Any])
-    /**
-     Data stream received from `Peer`.
-     */
-    case receivedStream(peer: Peer, stream: Stream, name: String)
-    /**
-     Started receiving a resource from `Peer` with name and `NSProgress`.
-     */
-    case startedReceivingResource(peer: Peer, name: String, progress: Progress)
-    /**
-     Finished receiving resource from `Peer` with name at url with optional error.
-     */
-    case finishedReceivingResource(peer: Peer, name: String, url: URL?, error: Error?)
-    /**
-     Received security certificate from `Peer` with handler.
-     */
-    case receivedCertificate(peer: Peer, certificate: [Any]?, handler: (Bool)->Void)
-    /**
-     Received a `PeerConnectionError`.
-     */
-    case error(Error)
-    /**
-     `PeerConnectionManager` was succesfully stopped.
-     */
+
+    /// `PeerConnectionManager` was succesfully stopped.
     case ended
-    /**
-     Found nearby `Peer`.
-     */
-    case foundPeer(peer: Peer)
-    /**
-     Lost nearby `Peer`.
-     */
+
+    /// Received a `PeerConnectionError`.
+    case error(Error)
+
+    // - Session peer updates
+
+    /// Devices changed event which returns the `Peer` that changed along with the connected `Peer`s. Check the passed `Peer`'s `Status` to see what changed.
+    case devicesChanged(session: PeerSession, peer: Peer, connectedPeers: [Peer])
+
+    // - Advertiser
+
+    /// Received invitation from `Peer` with optional context data and invitation handler.
+    case receivedInvitation(peer: Peer, withContext: Data?, invitationHandler: (Bool) -> Void)
+
+    // - Browser Peer/Advertiser discovery
+
+    /// Found nearby `Peer`.
+    case foundPeer(peer: Peer, info: DiscoveryInfo?)
+
+    /// Lost nearby `Peer`.
     case lostPeer(peer: Peer)
-    /**
-     Nearby peers changed.
-     */
+
+    /// Nearby peers changed.
     case nearbyPeersChanged(foundPeers: [Peer])
-    /**
-     Received invitation from `Peer` with optional context data and invitation handler.
-     */
-    case receivedInvitation(peer: Peer, withContext: Data?, invitationHandler: (Bool)->Void)
+
+    // - Data Reception
+
+    /// Data received from `Peer`.
+    case receivedData(session: PeerSession, peer: Peer, data: Data)
+
+    /// Event received from `Peer`.
+    case receivedEvent(session: PeerSession, peer: Peer, eventInfo: [String: Any])
+
+    /// Data stream received from `Peer`.
+    case receivedStream(session: PeerSession, peer: Peer, stream: Stream, name: String)
+
+    /// Started receiving a resource from `Peer` with name and `NSProgress`.
+    case startedReceivingResource(session: PeerSession, peer: Peer, name: String, progress: Progress)
+
+    /// Finished receiving resource from `Peer` with name at url with optional error.
+    case finishedReceivingResource(session: PeerSession, peer: Peer, name: String, url: URL?, error: Error?)
+
+    /// Received security certificate from `Peer` with handler.
+    case receivedCertificate(session: PeerSession, peer: Peer, certificate: [Any]?, handler: (Bool) -> Void)
+
 }
 
-/**
- Listener for responding to `PeerConnectionEvent`s.
- */
-public typealias PeerConnectionEventListener = (PeerConnectionEvent)->Void
+/// Listener for responding to `PeerConnectionEvent`s.
+public typealias PeerConnectionEventListener = (PeerConnectionEvent) -> Void
 
 internal class PeerConnectionResponder {
-    
-    fileprivate let peerEventObserver : MultiObservable<PeerConnectionEvent>
-    
-    internal fileprivate(set) var listeners : [String:PeerConnectionEventListener] = [:]
-    
+
+    // MARK: - Private Properties -
+
+    fileprivate let peerEventObserver: MultiObservable<PeerConnectionEvent>
+    internal fileprivate(set) var listeners: [String: PeerConnectionEventListener] = [:]
+
+    // MARK: - Initializers -
+
     internal init(observer: MultiObservable<PeerConnectionEvent>) {
         peerEventObserver = observer
     }
+
+    // MARK: - Listener Manipulation Add/Remove -
     
-    @discardableResult internal func addListener(_ listener: @escaping PeerConnectionEventListener, forKey key: String) -> PeerConnectionResponder {
+    @discardableResult internal func addListener(_ listener: @escaping PeerConnectionEventListener,
+                                                 forKey key: String) -> PeerConnectionResponder {
         listeners[key] = listener
         peerEventObserver.addObserver(listener, key: key)
         return self

--- a/Sources/PeerSession.swift
+++ b/Sources/PeerSession.swift
@@ -9,22 +9,55 @@
 import Foundation
 import MultipeerConnectivity
 
-internal struct PeerSession {
+public struct PeerSession {
+
+    // MARK: - Properties -
     
-    internal let peer : Peer
-    internal let session : MCSession
-    fileprivate let eventProducer: PeerSessionEventProducer
-    
-    internal var connectedPeers : [Peer] {
+    public let peer: Peer
+    public let servicePeer: Peer
+
+    internal let session: MCSession
+    fileprivate let eventProducer: PeerSessionEventProducer?
+
+    // MARK: - Computed Properties -
+
+    public var isLocalServiceSession: Bool {
+        return peer == servicePeer
+    }
+
+    public var isDistantServiceSession: Bool {
+        return isLocalServiceSession == false
+    }
+
+    public var connectedPeers: [Peer] {
         return session.connectedPeers.map { Peer(peerID: $0, status: .connected) }
     }
-    
-    internal init(peer: Peer, eventProducer: PeerSessionEventProducer) {
+
+    // MARK: - Initializer -
+
+    internal init(peer: Peer, servicePeer: Peer? = nil, eventProducer: PeerSessionEventProducer,
+                  securityIdentity identity: [Any]? = nil, encryptionPreference: MCEncryptionPreference = .optional) {
         self.peer = peer
+        self.servicePeer = servicePeer ?? peer
         self.eventProducer = eventProducer
-        session = MCSession(peer: peer.peerID, securityIdentity: nil, encryptionPreference: .optional)
+        session = MCSession(peer: peer.peerID, securityIdentity: identity, encryptionPreference: encryptionPreference)
         session.delegate = eventProducer
     }
+
+    internal init(peer: Peer, session: MCSession) {
+        self.peer = peer
+        self.servicePeer = peer
+
+        self.session = session
+        self.eventProducer = session.delegate as? PeerSessionEventProducer
+    }
+
+    init(session: MCSession, sessionPeerStatus: Peer.Status = .connected) {
+        let sessionPeer = Peer(peerID: session.myPeerID, status: sessionPeerStatus)
+        self.init(peer: sessionPeer, session: session)
+    }
+
+    // MARK: - Session Management -
     
     internal func startSession() {
         session.delegate = eventProducer
@@ -34,14 +67,13 @@ internal struct PeerSession {
         session.disconnect()
         session.delegate = nil
     }
+
+    // MARK: - Data Transfers -
     
     internal func sendData(_ data: Data, toPeers peers: [Peer] = []) {
         do {
-            try session.send(data,
-                toPeers: peers.isEmpty
-                    ? session.connectedPeers
-                    : peers.map { $0.peerID },
-                with: MCSessionSendDataMode.reliable)
+            let peers = peers.isEmpty ? session.connectedPeers : peers.map { $0.peerID }
+            try session.send(data, toPeers: peers, with: MCSessionSendDataMode.reliable)
         } catch let error {
             NSLog("%@", "Error sending data: \(error)")
         }
@@ -57,21 +89,18 @@ internal struct PeerSession {
         }
     }
     
-    internal func sendResourceAtURL(_ resourceURL: URL,
-        withName name: String,
-        toPeer peer: Peer,
-        withCompletionHandler completion: ((Error?)->Void)?) -> Progress? {
-        
-        return session.sendResource(at: resourceURL,
-            withName: name,
-            toPeer: peer.peerID,
-            withCompletionHandler: completion)
+    internal func sendResourceAtURL(_ resourceURL: URL, withName name: String, toPeer peer: Peer,
+                                    withCompletionHandler completion: ((Error?)->Void)?) -> Progress? {
+        return session.sendResource(at: resourceURL, withName: name, toPeer: peer.peerID,
+                                    withCompletionHandler: completion)
     }
     
     // TODO: - Alternative methods of finding peers not yet supported.
     
-    internal func nearbyConnectionDataForPeer(_ peer: Peer, withCompletionHandler completion: @escaping (Data, Error?) -> Void) {
-        session.nearbyConnectionData(forPeer: peer.peerID, withCompletionHandler: completion as! (Data?, Error?) -> Void)
+    internal func nearbyConnectionDataForPeer(_ peer: Peer,
+                                              withCompletionHandler completion: @escaping (Data, Error?) -> Void) {
+        session.nearbyConnectionData(forPeer: peer.peerID,
+                                     withCompletionHandler: completion as! (Data?, Error?) -> Void)
     }
     
     internal func connectPeer(_ peer: Peer, withNearbyConnectionData data: Data) {
@@ -82,4 +111,48 @@ internal struct PeerSession {
         session.cancelConnectPeer(peer.peerID)
     }
     
+}
+
+// MARK: - Protocols
+// MARK: - Hashable, Equatable
+
+extension PeerSession: Hashable, Equatable {
+
+    /// :nodoc:
+    public var hashValue: Int {
+        return session.hashValue
+    }
+
+    /// :nodoc:
+    public static func ==(lhs: PeerSession, rhs: PeerSession) -> Bool {
+        return lhs.session == rhs.session
+    }
+
+    /// :nodoc:
+    public static func ==(lhs: PeerSession, rhs: Peer) -> Bool {
+        return lhs.session.connectedPeers.contains(rhs.peerID)
+    }
+
+}
+
+func addressHeap<T: AnyObject>(_ o: T) -> Int {
+    return unsafeBitCast(o, to: Int.self)
+}
+
+// MARK: - CustomStringConvertible & CustomDebugStringConvertible
+
+extension PeerSession: CustomStringConvertible, CustomDebugStringConvertible {
+
+    public var description: String {
+        return debugDescription
+    }
+
+    public var debugDescription: String {
+        let sessionAddress = String(addressHeap(session), radix: 16, uppercase: false)
+        let serviceType = isLocalServiceSession ? "local-service" : "distant-service"
+
+        return "<<\(type(of: self))> session: 0x\(sessionAddress); type = \(serviceType); "
+             + "servicePeer = \(servicePeer.peerID); peers = \(connectedPeers.count)>"
+    }
+
 }


### PR DESCRIPTION
## Description

**status**: last testing stage

This might looks like a lots of change but the pull-request include differents things:
  - new files and update to projects / settings (.gitignore, pod spec, example project, playground)
  - some reoganisation of extensions into new files or re-order of properties of functions
  - update multiple types with news attributes for feature like 'security', 'discoveryInfo' & 'connectionMode'
 - update of the `EventProducers` for `Sessions`, `Advertiser` & `Browser`
 
#### `Sessions` - `MCSession` delegate & event producer

`PeerSession` can represent either a `advertiser` session (local-service) or a connection to a 'distant-service' invited through `PeerBrowser`

thus we now have access to the following attributes:
 -  `sessionPeer` - indicate this is a `distance-service-session` and represent the peer advertising that servicer
 - `isLocalServiceSession` - computed property that check `peer` against `peerSession`
 - `isDistantServiceSession` - computed property too

`PeerSession` can now take `security` parameter at `init` allowing to configurer the kind of security to use on the `MCSession` 

#### `Advertisers` - `MCNearbyServiceAdvertiser` delegate & event producer

Advertiser didn't change too much, we can now use `discoverInfo` at init which couple with `Peer.context` allow better introspection of services and peer.

Before we used poorly named service to differentiate environment or restaurants, now we can name our services simply and use `discoveryInfo` to filter matching services.

#### `Browser` - `MCNearbyServiceBrowser` delegate & event producer

Main change to browser is the new `sessionFactory` logic introduced.
The browser will use the `sessions` attribute when uses as a single `slave` connection,
but will create new session through the factory if configured as `node` browser.

This will allow to create new session for each services we're connecting to.


 