### PR TITLE
Feature - Allow connection retry/attempt with 'Invitation' 

### DIFF
--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -107,4 +107,9 @@ extension Peer: Hashable, Equatable {
         return lhs.peerID == rhs.peerID
     }
 
+    /// :nodoc:
+    public static func ===(lhs: Peer, rhs: Peer) -> Bool {
+        return lhs.peerID === rhs.peerID
+    }
+
 }

--- a/Sources/PeerAdvertiserEventProducer.swift
+++ b/Sources/PeerAdvertiserEventProducer.swift
@@ -38,6 +38,7 @@ extension PeerAdvertiserEventProducer: MCNearbyServiceAdvertiserDelegate {
         NSLog("%@", "didReceiveInvitationFromPeer \(peerID)")
         
         let handler: ((Bool, PeerSession) -> Void) = { (accept, session) in
+            NSLog("%@", "invitationHandler \(peerID), accept \(accept), session \(session)")
             invitationHandler(accept, session.session)
         }
         

--- a/Sources/PeerBrowser.swift
+++ b/Sources/PeerBrowser.swift
@@ -11,6 +11,45 @@ import MultipeerConnectivity
 
 typealias SessionFactory = (Peer, Data?) -> PeerSession
 
+internal struct Invitation {
+
+    // MARK: - Constants && Types
+
+    static let maxConnectionRetries = 3
+
+    // MARK: - Properties
+
+    internal let peer: Peer
+    internal let session: PeerSession
+
+    internal var context: Data?
+    internal var retryCount: Int = 0
+
+    // MARK: - Initializers
+
+    init(peer: Peer, session: PeerSession, context: Data? = nil, retryCount: Int = 0) {
+        self.peer = peer
+        self.session = session
+
+        self.context = context
+        self.retryCount = retryCount
+    }
+
+}
+
+extension Invitation: Equatable {
+
+    public static func == (lhs: Invitation, rhs: Invitation) -> Bool {
+        return lhs.peer == rhs.peer
+    }
+
+    public static func == (lhs: Invitation, rhs: Peer) -> Bool {
+        return lhs.peer == rhs
+    }
+
+}
+
+
 internal struct PeerBrowser {
 
     // MARK: - Properties -
@@ -21,6 +60,8 @@ internal struct PeerBrowser {
     fileprivate var browser: MCNearbyServiceBrowser
     fileprivate let eventProducer: PeerBrowserEventProducer
     fileprivate let sessionFactory: SessionFactory?
+
+    internal var invitations: [Invitation] = []
 
     // MARK: - Initializers -
     
@@ -61,12 +102,65 @@ internal struct PeerBrowser {
 
     // MARK: - Browser peer management -
 
-    internal func invitePeer(_ peer: Peer, withContext context: Data? = nil, timeout: TimeInterval = 30) throws {
-        guard let session = self.session ?? sessionFactory?(peer, context) else {
+    internal func invitation(for peer: Peer) -> (Int, Invitation)? {
+        guard let invitation = invitations.first(where: { $0 == peer }),
+            let index = invitations.firstIndex(of: invitation) else {
+                return nil
+        }
+
+        return (index, invitation)
+    }
+
+    internal mutating func invitePeer(invitation: Invitation, context: Data? = nil, timeout: TimeInterval = 30) throws {
+        var invitation = invitation // TODO: Check that connection of peer entered 'connecting' before retry connection
+        guard let index = invitations.firstIndex(of: invitation) else {
+            throw PeerConnectionManager.Error.unknownInvitation
+        }
+
+        guard invitation.retryCount < Invitation.maxConnectionRetries else {
+            invitations.remove(at: index)
+            throw PeerConnectionManager.Error.maxConnectionRetriesExceeded
+        }
+
+        invitation.retryCount += 1
+        invitation.context = context ?? invitation.context
+        invitations[index] = invitation
+
+        let invitationPeer = invitation.peer
+        let invitationSession = invitation.session
+        let invitationContext = invitation.context
+
+        browser.invitePeer(invitationPeer.peerID, to: invitationSession.session,
+                           withContext: invitationContext, timeout: timeout)
+
+        var contextValue: [String: Any]? = nil
+        if let context = context {
+            contextValue = (try? JSONSerialization.jsonObject(with: context, options: .allowFragments)) as? [String: Any]
+        }
+        NSLog("%@", "peer invited \(invitationPeer.peerID), retry: \(invitation.retryCount), " +
+                    "session: \(invitationSession), context: \(contextValue ?? [:])")
+    }
+
+    internal mutating func invitePeer(_ peer: Peer, session: PeerSession? = nil,
+                                      withContext context: Data? = nil, timeout: TimeInterval = 30) throws {
+        if var invitation = invitations.first(where: { $0 == peer && $0.peer === peer }) {
+            try invitePeer(invitation: invitation, context: context, timeout: timeout)
+            return
+        }
+
+        guard let session = self.session ?? session ?? sessionFactory?(peer, context) else {
             throw PeerConnectionManager.Error.unsupportedModeUsage
         }
 
+        let invitation = Invitation(peer: peer, session: session, context: context)
+        invitations.append(invitation)
         browser.invitePeer(peer.peerID, to: session.session, withContext: context, timeout: timeout)
+
+        var contextValue: [String: Any]? = nil
+        if let context = context {
+            contextValue = (try? JSONSerialization.jsonObject(with: context, options: .allowFragments)) as? [String: Any]
+        }
+        NSLog("%@", "peer invited \(peer.peerID) session: \(session), context: \(contextValue ?? [:])")
     }
 
 }

--- a/Sources/PeerSession.swift
+++ b/Sources/PeerSession.swift
@@ -52,6 +52,14 @@ public struct PeerSession {
         self.eventProducer = session.delegate as? PeerSessionEventProducer
     }
 
+    internal init(session: PeerSession, peer: Peer, servicePeer: Peer? = nil) {
+        self.peer = peer
+        self.servicePeer = servicePeer ?? peer
+
+        self.session = session.session
+        self.eventProducer = session.eventProducer
+    }
+
     init(session: MCSession, sessionPeerStatus: Peer.Status = .connected) {
         let sessionPeer = Peer(peerID: session.myPeerID, status: sessionPeerStatus)
         self.init(peer: sessionPeer, session: session)
@@ -73,6 +81,11 @@ public struct PeerSession {
     internal func sendData(_ data: Data, toPeers peers: [Peer] = []) {
         do {
             let peers = peers.isEmpty ? session.connectedPeers : peers.map { $0.peerID }
+
+            guard peers.isEmpty == false else {
+                return
+            }
+
             try session.send(data, toPeers: peers, with: MCSessionSendDataMode.reliable)
         } catch let error {
             NSLog("%@", "Error sending data: \(error)")


### PR DESCRIPTION
### Description

Adds 'Invitation' type directly managed by `PeerBrowser`, once a user called `Invite` through `PeerManager` the `PeerBrowser` will check it's invitation array.

This allow multiple fixes and security in the connections business logics:
 - It prevent a user to invite the same peer multiple times.
 - it allow `PeerManager` to retry invitation when the connection failed
 - It also allow to reconnect to peers/advertiser reused by `MultipeerConnectivity` when a distant `PeerAdvertiser` has been stop and restart in a small amount of time.
