### PR TITLE
Feature - Adds 'Invitation.Status', better identification of invitation state

### DIFF
--- a/PeerConnectivity.podspec
+++ b/PeerConnectivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PeerConnectivity"
-  s.version      = "2.1.0-beta"
+  s.version      = "2.1.1"
 
   s.summary      = "Functional wrapper for Apple's MultipeerConnectivity framework."
   s.description  = <<-DESC

--- a/PeerConnectivity.podspec
+++ b/PeerConnectivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PeerConnectivity"
-  s.version      = "2.0.0-beta"
+  s.version      = "2.1.0-beta"
 
   s.summary      = "Functional wrapper for Apple's MultipeerConnectivity framework."
   s.description  = <<-DESC

--- a/PeerConnectivity.xcodeproj/project.pbxproj
+++ b/PeerConnectivity.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		9C0B1A9B21A84049001AB7BB /* ThreadSafeValueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B1A9A21A84049001AB7BB /* ThreadSafeValueWrapper.swift */; };
 		9C8518E42182172D000C5C3F /* PeerConnectionManager+Peer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8518E32182172D000C5C3F /* PeerConnectionManager+Peer.swift */; };
 		9C8518E621821763000C5C3F /* PeerConnectionManager+Listener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8518E521821763000C5C3F /* PeerConnectionManager+Listener.swift */; };
+		9CEEDB2F21BECDBD00AF0505 /* Invitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEEDB2E21BECDBD00AF0505 /* Invitation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -75,6 +76,7 @@
 		9C0B1A9A21A84049001AB7BB /* ThreadSafeValueWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafeValueWrapper.swift; sourceTree = "<group>"; };
 		9C8518E32182172D000C5C3F /* PeerConnectionManager+Peer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "PeerConnectionManager+Peer.swift"; path = "Sources/PeerConnectionManager+Peer.swift"; sourceTree = "<group>"; };
 		9C8518E521821763000C5C3F /* PeerConnectionManager+Listener.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "PeerConnectionManager+Listener.swift"; path = "Sources/PeerConnectionManager+Listener.swift"; sourceTree = "<group>"; };
+		9CEEDB2E21BECDBD00AF0505 /* Invitation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Invitation.swift; path = Sources/Invitation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +106,6 @@
 				9C805C8D21628443006FA28D /* Adviser */,
 				9C805C8E21628457006FA28D /* Browser */,
 				9C805C8F2162847B006FA28D /* ObserverResponder */,
-				3080C7DE1D80A1D600AF9EA3 /* Peer.swift */,
 				3080C7E71D80A1D600AF9EA3 /* PeerConnectionManager.swift */,
 				9C8518E32182172D000C5C3F /* PeerConnectionManager+Peer.swift */,
 				9C8518E521821763000C5C3F /* PeerConnectionManager+Listener.swift */,
@@ -144,6 +145,8 @@
 			isa = PBXGroup;
 			children = (
 				9C0B1A8F21A83FFD001AB7BB /* AtomicKit */,
+				3080C7DE1D80A1D600AF9EA3 /* Peer.swift */,
+				9CEEDB2E21BECDBD00AF0505 /* Invitation.swift */,
 			);
 			name = Commons;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				9C0B1A9621A83FFD001AB7BB /* Mutex.swift in Sources */,
 				3080C7EF1D80A1D700AF9EA3 /* Peer.swift in Sources */,
 				9C0B1A9921A84025001AB7BB /* UnfairLock.swift in Sources */,
+				9CEEDB2F21BECDBD00AF0505 /* Invitation.swift in Sources */,
 				3080C7F91D80A1D700AF9EA3 /* PeerConnectionResponder.swift in Sources */,
 				3080C7F71D80A1D700AF9EA3 /* PeerBrowserViewControllerEventProducer.swift in Sources */,
 				3080C7F41D80A1D700AF9EA3 /* PeerBrowser.swift in Sources */,

--- a/Sources/Invitation.swift
+++ b/Sources/Invitation.swift
@@ -1,0 +1,136 @@
+//
+//  Invitation.swift
+//  PeerConnectivity
+//
+//  Created by Julien Di Marco on 10/12/2018.
+//  Copyright © 2018 Reid Chatham. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Invitation Constant && Types -
+
+public enum InvitationError: Swift.Error {
+    case invitationPending
+    case connectionInconsistency
+    case maxConnectionRetriesExceeded
+}
+
+// MARK: - Main Invitation Definition -
+
+internal struct Invitation {
+
+    // MARK: - Constants && Types
+
+    static let maxConnectionRetries = 3
+    static let maxInconsistentConnectionRetries = 1
+
+    public enum Status {
+        /// Invitation was initialized, a `PeerBrowser` might have called `invitedPeer`
+        case unknown
+
+        /// `PeerBrowser` called `invitePeer` and `Session` received `.connecting`
+        case pending
+
+        /// Invitation failed, `Session` received `.notConnected`, retry count is increment
+        case failed
+
+        /// Invitation failed without becoming '.pending', retryCount is reset
+        case inconsistent
+    }
+
+    // MARK: - Properties
+
+    internal let peer: Peer
+    internal let session: PeerSession
+
+    internal var context: Data?
+    internal var retryCount: Int = 0
+    internal var status: Status = .unknown
+
+    // MARK: - Initializers
+
+    init(peer: Peer, session: PeerSession, context: Data? = nil, retryCount: Int = 0) {
+        self.peer = peer
+        self.session = session
+
+        self.context = context
+        self.retryCount = retryCount
+    }
+
+    init(_ invitation: Invitation, status: Status, session: PeerSession? = nil, context: Data? = nil) throws {
+        self.peer = invitation.peer
+        self.session = session ?? invitation.session
+        self.context = context ?? invitation.context
+
+        switch status {
+        case .inconsistent:
+            self.status = .inconsistent
+            self.retryCount = (invitation.status == .inconsistent) ? invitation.retryCount + 1 : 0
+
+            guard invitation.retryCount < Invitation.maxInconsistentConnectionRetries else {
+                throw InvitationError.maxConnectionRetriesExceeded
+            }
+
+        case .failed:
+            guard invitation.status == .pending else {
+                throw InvitationError.connectionInconsistency
+            }
+
+            guard invitation.retryCount < Invitation.maxConnectionRetries else {
+                throw InvitationError.maxConnectionRetriesExceeded
+            }
+
+            self.status = status
+            self.retryCount = invitation.retryCount + 1
+
+        default:
+            self.status = status
+            self.retryCount = invitation.retryCount
+        }
+    }
+
+}
+
+// MARK: - Protocols
+// MARK: - Equatable
+
+extension Invitation: Equatable {
+
+    public static func == (lhs: Invitation, rhs: Invitation) -> Bool {
+        return lhs.peer == rhs.peer
+    }
+
+    public static func == (lhs: Invitation, rhs: Peer) -> Bool {
+        return lhs.peer == rhs
+    }
+
+}
+
+// MARK: - CustomStringConvertible, CustomDebugStringConvertible
+
+extension Invitation: CustomStringConvertible, CustomDebugStringConvertible {
+
+    public var description: String {
+        return debugDescription
+    }
+
+    public var debugDescription: String {
+        let peerAddress = String(addressHeap(peer.peerID), radix: 16, uppercase: false)
+        let sessionAddress = String(addressHeap(session.session), radix: 16, uppercase: false)
+
+        return "<<\(type(of: self))> status: \(status); retryCount: \(retryCount); "
+            + "peer: 0x\(peerAddress); session: 0x\(sessionAddress)>"
+    }
+}
+
+// MARK: - Serialization helper -
+
+internal extension Data {
+
+    var jsonDictionary: [String: Any]? {
+        return (try? JSONSerialization.jsonObject(with: self, options: .allowFragments)) as? [String: Any]
+    }
+
+}
+

--- a/Sources/PeerBrowser.swift
+++ b/Sources/PeerBrowser.swift
@@ -63,6 +63,7 @@ internal struct PeerBrowser {
 
     // MARK: - Browser Invitation Management -
 
+    @discardableResult
     internal mutating func updateInvitation(for peer: Peer, status: Peer.Status) -> Bool {
         guard let (index, invitation) = invitation(for: peer), invitation.peer === peer else {
             return false
@@ -141,7 +142,7 @@ internal struct PeerBrowser {
                 logger.info("PeerBrowser Manager - invitation removed - \(invitation)")
                 throw PeerConnectionManager.Error.maxConnectionRetriesExceeded
 
-            default: InvitationError.invitationPending
+            default: throw InvitationError.invitationPending
             }
         }
     }

--- a/Sources/PeerBrowserEventProducer.swift
+++ b/Sources/PeerBrowserEventProducer.swift
@@ -63,7 +63,7 @@ extension PeerBrowserEventProducer: MCNearbyServiceBrowserDelegate {
         let peer = Peer(peerID: peerID, status: .available, info: info)
         let event: PeerBrowserEvent = .foundPeer(peer, info)
 
-        logger.error("PeerBrowserEventProducer - \(event)")
+        logger.info("PeerBrowserEventProducer - \(event)")
         self.observer.value = event
     }
     
@@ -71,7 +71,7 @@ extension PeerBrowserEventProducer: MCNearbyServiceBrowserDelegate {
         let peer = Peer(peerID: peerID, status: .unavailable)
         let event: PeerBrowserEvent = .lostPeer(peer)
 
-        logger.error("PeerBrowserEventProducer - \(event)")
+        logger.info("PeerBrowserEventProducer - \(event)")
         self.observer.value = event
     }
 

--- a/Sources/PeerConnectionManager+Peer.swift
+++ b/Sources/PeerConnectionManager+Peer.swift
@@ -12,6 +12,7 @@ import Foundation
 
 public extension PeerConnectionManager {
 
+    @discardableResult
     public func peerServiceAvailable(_ peer: Peer) throws -> Bool  {
         /// ^ is equal check internal 'MCPeer', here we need to compare instance too
         /// similar to generation trick ^^
@@ -72,13 +73,14 @@ public extension PeerConnectionManager {
             }
 
             try? strongSelf.invitePeer(peer, withContext: context, timeout: timeout)
+            reconnectWorkItem = nil
         }
 
-        let deadline: DispatchTime = .now() + delay
         guard let connectionWorkItem = reconnectWorkItem else {
             return
         }
 
+        let deadline: DispatchTime = .now() + delay
         retyAttemptQueue?.asyncAfter(deadline: deadline, execute: connectionWorkItem)
     }
 

--- a/Sources/PeerConnectionManager.swift
+++ b/Sources/PeerConnectionManager.swift
@@ -267,8 +267,8 @@ extension PeerConnectionManager {
         configureObserverResponseEventDispatch()
         try configureDefaultConnectionTypeBehavior()
 
-        retyAttemptQueue = DispatchQueue(label: "com.peerconnetion.retry-attempt-queue",
-                                         qos: .userInitiated, autoreleaseFrequency: .workItem)
+        retyAttemptQueue = DispatchQueue(label: "com.peerconnetion.retry-attempt-queue",  qos: .userInitiated,
+                                         attributes: .concurrent, autoreleaseFrequency: .workItem)
 
         session.startSession()
         browser?.startBrowsing()
@@ -465,7 +465,7 @@ extension PeerConnectionManager {
 
     private func configureManagerPeerObservers() {
         browserObserver.addObserver { [weak self] event in
-            DispatchQueue.main.async {
+            DispatchQueue.global().async {
                 self?.mutex.lock()
                 defer { self?.mutex.unlock() }
 

--- a/Sources/PeerConnectionResponder.swift
+++ b/Sources/PeerConnectionResponder.swift
@@ -71,6 +71,7 @@ public enum PeerConnectionEvent: CustomDebugStringConvertible {
         case .ready: return "ready"
         case .started: return "started - start session, advertiser and browsing"
         case .ended: return "ended - stop session, advertiser and browsing"
+        case .nearbyPeersChanged(let peers): return "nearbyPeersChanged(peers: \(peers.count))"
         default: return Mirror(reflecting: self).children.first?.label ?? ""
         }
     }

--- a/Sources/PeerSession.swift
+++ b/Sources/PeerSession.swift
@@ -148,7 +148,7 @@ extension PeerSession: Hashable, Equatable {
 
 }
 
-func addressHeap<T: AnyObject>(_ o: T) -> Int {
+internal func addressHeap<T: AnyObject>(_ o: T) -> Int {
     return unsafeBitCast(o, to: Int.self)
 }
 


### PR DESCRIPTION
### Description

Adds new `Invitation.Status` type which help identify in which state in the invitation (and thus peer) is.

Possible cases are `unknown`, `pending`, `failed` and `inconsistent` in order.

Best case scenario a invitation would see the following status: 
> `unknown` -> `pending` -> invitation removed

In case the invitation fail the following status would happen:
> `unknown` -> `pending` -> `failed` -> `pending` -> `failed` -> `pending` -> invitation removed

in worst case scenario the invitation would fail quickly:
> `unknown` -> `inconsistent` -> `inconsistent` -> still failing = ignoring peer
