### PR TITLE
Feature - OO-843 - Reuse 'ServiceSession' for 'SendData'

### DIFF
--- a/PeerConnectivity.podspec
+++ b/PeerConnectivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PeerConnectivity"
-  s.version      = "2.2.0-beta"
+  s.version      = "2.2.1"
 
   s.summary      = "Functional wrapper for Apple's MultipeerConnectivity framework."
   s.description  = <<-DESC

--- a/PeerConnectivity.podspec
+++ b/PeerConnectivity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "PeerConnectivity"
-  s.version      = "2.1.3"
+  s.version      = "2.2.0-beta"
 
   s.summary      = "Functional wrapper for Apple's MultipeerConnectivity framework."
   s.description  = <<-DESC

--- a/Sources/PeerConnectionManager.swift
+++ b/Sources/PeerConnectionManager.swift
@@ -97,6 +97,16 @@ public class PeerConnectionManager {
         })
     }
 
+    public var allAvailableSessions: [PeerSession] {
+        return [session] + servicesSessions
+    }
+
+    public var allAvailablePeers: [Peer] {
+        return servicesSessions.reduce(connectedPeers, { (peers, serviceSession) -> [Peer] in
+            return Array(Set(peers + [serviceSession.servicePeer]))
+        })
+    }
+
     /// Nearby peers available for connecting.
     ///
     /// - Note: Can be observed by listening for PeerConnectivityEvent.nearbyPeersChanged(foundPeers:).

--- a/Sources/PeerConnectionManager.swift
+++ b/Sources/PeerConnectionManager.swift
@@ -103,7 +103,7 @@ public class PeerConnectionManager {
 
     public var allAvailablePeers: [Peer] {
         return servicesSessions.reduce(connectedPeers, { (peers, serviceSession) -> [Peer] in
-            return Array(Set(peers + [serviceSession.servicePeer]))
+            return Array(Set(peers + [serviceSession.servicePeer] + serviceSession.connectedPeers))
         })
     }
 

--- a/Sources/logger/Logger.swift
+++ b/Sources/logger/Logger.swift
@@ -43,5 +43,7 @@ public let logger: Logger = {
     logger.add(destination: LoggerDomain.peerConnectivity.fileDestination)
     logger.add(destination: LoggerDomain.peerConnectivity.oslogDestination)
 
+    logger.outputLevel = .verbose
+
     return logger
 }()

--- a/Sources/logger/Logger.swift
+++ b/Sources/logger/Logger.swift
@@ -43,7 +43,7 @@ public let logger: Logger = {
     logger.add(destination: LoggerDomain.peerConnectivity.fileDestination)
     logger.add(destination: LoggerDomain.peerConnectivity.oslogDestination)
 
-    logger.outputLevel = .verbose
+    logger.outputLevel = .error
 
     return logger
 }()


### PR DESCRIPTION
### Description

To improve performance and connectivity, I've change 'sendData' in `PeerConnectionManager`,
to use both local `session` and available `serviceSession`.

Using `allAvailablePeers` computed from `serviceSession.connectedPeer`, local `session.connectedPeer` and all `servicePeer`.

This provide a complete picture of all `peers` connected together.
It allow a single device to forward data to more peers than previously possible.
Using the same `mesh` architecture but using more of the available connections.